### PR TITLE
test: increase coverage to 50%

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,19 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "coverageThreshold": {
+      "global": {
+        "statements": 50,
+        "branches": 25,
+        "functions": 40,
+        "lines": 50
+      }
+    },
+    "coveragePathIgnorePatterns": [
+      "/index\\.ts$",
+      "\\.interface\\.ts$",
+      "\\.types\\.ts$"
+    ]
   }
 }

--- a/src/controllers/sse/sse.service.spec.ts
+++ b/src/controllers/sse/sse.service.spec.ts
@@ -1,0 +1,35 @@
+import { DiscoveryModule } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { DiscoveryService } from '../../registry/discovery.service';
+import { McpLoggerService } from '../../registry/logger.service';
+import { RegistryService } from '../../registry/registry.service';
+import { SessionManager } from '../../services/session.manager';
+import { SseService } from './sse.service';
+
+describe('SseService', () => {
+  let service: SseService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [DiscoveryModule],
+      providers: [
+        SseService,
+        McpLoggerService,
+        RegistryService,
+        SessionManager,
+        DiscoveryService,
+        {
+          provide: 'MCP_SERVER_OPTIONS',
+          useValue: { serverInfo: {}, options: {} },
+        },
+      ],
+    }).compile();
+
+    service = module.get<SseService>(SseService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/controllers/streamable/streamable.service.spec.ts
+++ b/src/controllers/streamable/streamable.service.spec.ts
@@ -1,0 +1,39 @@
+import { DiscoveryModule } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { DiscoveryService } from '../../registry/discovery.service';
+import { McpLoggerService } from '../../registry/logger.service';
+import { RegistryService } from '../../registry/registry.service';
+import { SessionManager } from '../../services/session.manager';
+import { StreamableService } from './streamable.service';
+
+describe('StreamableService', () => {
+  let service: StreamableService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [DiscoveryModule],
+      providers: [
+        StreamableService,
+        McpLoggerService,
+        RegistryService,
+        SessionManager,
+        DiscoveryService,
+        {
+          provide: 'MCP_SERVER_OPTIONS',
+          useValue: { serverInfo: {}, options: {} },
+        },
+        {
+          provide: 'MCP_TRANSPORT_OPTIONS',
+          useValue: { streamable: { options: {} } },
+        },
+      ],
+    }).compile();
+
+    service = module.get<StreamableService>(StreamableService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/decorators/capabilities.decorators.spec.ts
+++ b/src/decorators/capabilities.decorators.spec.ts
@@ -1,0 +1,133 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import 'reflect-metadata';
+import { z } from 'zod';
+
+import { MCP_PROMPT, MCP_RESOURCE, MCP_TOOL } from './capabilities.constants';
+import {
+  MCP_GUARDS,
+  MCP_RESOLVER,
+  Prompt,
+  Resolver,
+  Resource,
+  Tool,
+  UseGuards,
+} from './capabilities.decorators';
+
+describe('MCP Decorators', () => {
+  it('should apply Resolver metadata', () => {
+    @Resolver('test')
+    class TestClass {}
+
+    expect(Reflect.getMetadata(MCP_RESOLVER, TestClass)).toBe('test');
+  });
+
+  it('should apply UseGuards metadata', () => {
+    class Guard {}
+
+    @UseGuards(Guard)
+    class TestClass {}
+
+    expect(Reflect.getMetadata(MCP_GUARDS, TestClass)).toContain(Guard);
+  });
+
+  it('should apply Tool metadata in a Nest module', async () => {
+    const schema = { foo: z.string() };
+
+    @Resolver('test')
+    class TestClass {
+      @Tool({ name: 'tool', paramSchema: schema })
+      toolMethod() {}
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TestClass],
+    }).compile();
+
+    const instance = module.get(TestClass);
+    const proto = Object.getPrototypeOf(instance) as Record<string, unknown>;
+
+    let metadataUnknown: unknown = Reflect.getMetadata(
+      MCP_TOOL,
+      proto,
+      'toolMethod',
+    );
+
+    if (!metadataUnknown) {
+      metadataUnknown = Reflect.getMetadata(
+        MCP_TOOL,
+        proto['toolMethod'] as object,
+      );
+    }
+
+    const metadata = metadataUnknown as { name?: string } | undefined;
+
+    expect(metadata).toBeDefined();
+    expect(metadata?.name).toBe('tool');
+  });
+
+  it('should apply Prompt metadata in a Nest module', async () => {
+    @Resolver('test')
+    class TestClass {
+      @Prompt({ name: 'prompt' })
+      promptMethod() {}
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TestClass],
+    }).compile();
+
+    const instance = module.get(TestClass);
+    const proto = Object.getPrototypeOf(instance) as Record<string, unknown>;
+
+    let metadataUnknown: unknown = Reflect.getMetadata(
+      MCP_PROMPT,
+      proto,
+      'promptMethod',
+    );
+
+    if (!metadataUnknown) {
+      metadataUnknown = Reflect.getMetadata(
+        MCP_PROMPT,
+        proto['promptMethod'] as object,
+      );
+    }
+
+    const metadata = metadataUnknown as { name?: string } | undefined;
+
+    expect(metadata).toBeDefined();
+    expect(metadata?.name).toBe('prompt');
+  });
+
+  it('should apply Resource metadata in a Nest module', async () => {
+    @Resolver('test')
+    class TestClass {
+      @Resource({ name: 'resource', uri: 'resource://test' })
+      resourceMethod() {}
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TestClass],
+    }).compile();
+
+    const instance = module.get(TestClass);
+    const proto = Object.getPrototypeOf(instance) as Record<string, unknown>;
+
+    let metadataUnknown: unknown = Reflect.getMetadata(
+      MCP_RESOURCE,
+      proto,
+      'resourceMethod',
+    );
+
+    if (!metadataUnknown) {
+      metadataUnknown = Reflect.getMetadata(
+        MCP_RESOURCE,
+        proto['resourceMethod'] as object,
+      );
+    }
+
+    const metadata = metadataUnknown as { name?: string } | undefined;
+
+    expect(metadata).toBeDefined();
+    expect(metadata?.name).toBe('resource');
+  });
+});

--- a/src/interfaces/capabilities.interface.ts
+++ b/src/interfaces/capabilities.interface.ts
@@ -113,6 +113,7 @@ export type RequestHandlerExtra = SdkRequestHandlerExtra<
   headers: Record<string, string>;
 };
 
+// TODO: This is not an interface
 export class ResourceUriHandlerParams {
   public readonly uri: URL;
   public readonly extra: RequestHandlerExtra;
@@ -127,6 +128,7 @@ export class ResourceUriHandlerParams {
   }
 }
 
+// TODO: This is not an interface
 export class ResourceTemplateHandlerParams {
   public readonly uri: URL;
   public readonly variables?: Record<string, string>;
@@ -151,6 +153,7 @@ export class ResourceTemplateHandlerParams {
   }
 }
 
+// TODO: This is not an interface
 export class PromptHandlerParams<
   Args extends PromptArgsRawShape | undefined = undefined,
 > {
@@ -179,6 +182,7 @@ export class PromptHandlerParams<
   }
 }
 
+// TODO: This is not an interface
 export class ToolHandlerParams<
   Args extends ZodRawShape | undefined = undefined,
 > {

--- a/src/registry/discovery.service.spec.ts
+++ b/src/registry/discovery.service.spec.ts
@@ -1,0 +1,43 @@
+import { DiscoveryModule } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import {
+  MCP_PROMPT,
+  MCP_RESOURCE,
+  MCP_TOOL,
+} from '../decorators/capabilities.constants';
+import { DiscoveryService } from './discovery.service';
+
+describe('DiscoveryService', () => {
+  let service: DiscoveryService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [DiscoveryModule],
+      providers: [DiscoveryService],
+    }).compile();
+    service = module.get(DiscoveryService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should return empty array for MCP_RESOURCE metadata', () => {
+    const methods = service.getAllMethodsWithMetadata(MCP_RESOURCE);
+    expect(methods).toBeDefined();
+    expect(methods.length).toBe(0);
+  });
+
+  it('should return empty array for MCP_PROMPT metadata', () => {
+    const methods = service.getAllMethodsWithMetadata(MCP_PROMPT);
+    expect(methods).toBeDefined();
+    expect(methods.length).toBe(0);
+  });
+
+  it('should return empty array for MCP_TOOL metadata', () => {
+    const methods = service.getAllMethodsWithMetadata(MCP_TOOL);
+    expect(methods).toBeDefined();
+    expect(methods.length).toBe(0);
+  });
+});

--- a/src/registry/logger.service.spec.ts
+++ b/src/registry/logger.service.spec.ts
@@ -1,0 +1,37 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { McpLoggerService } from './logger.service';
+
+describe('McpLoggerService', () => {
+  let service: McpLoggerService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [McpLoggerService],
+    }).compile();
+
+    service = module.get(McpLoggerService);
+    // Silenciar logger de NestJS
+    jest.spyOn(service['logger'], 'log').mockImplementation(() => {});
+    jest.spyOn(service['logger'], 'debug').mockImplementation(() => {});
+    jest.spyOn(service['logger'], 'verbose').mockImplementation(() => {});
+    jest.spyOn(service['logger'], 'warn').mockImplementation(() => {});
+    jest.spyOn(service['logger'], 'error').mockImplementation(() => {});
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should log without error', () => {
+    expect(() => service.log('test')).not.toThrow();
+    expect(() => service.debug('test')).not.toThrow();
+    expect(() => service.verbose('test')).not.toThrow();
+    expect(() => service.warn('test')).not.toThrow();
+    expect(() => service.error('test')).not.toThrow();
+  });
+
+  it('should return enabled and level', () => {
+    expect(typeof service.isEnabled()).toBe('boolean');
+    expect(typeof service.getLevel()).toBe('string');
+  });
+});

--- a/src/registry/registry.service.spec.ts
+++ b/src/registry/registry.service.spec.ts
@@ -1,0 +1,215 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import { DiscoveryModule, Reflector } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { SessionManager } from '../services/session.manager';
+import { DiscoveryService } from './discovery.service';
+import { McpLoggerService } from './logger.service';
+import { RegistryService } from './registry.service';
+
+describe('RegistryService', () => {
+  let service: RegistryService;
+
+  describe('with Nest TestingModule', () => {
+    beforeEach(async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        imports: [DiscoveryModule],
+        providers: [
+          RegistryService,
+          DiscoveryService,
+          McpLoggerService,
+          SessionManager,
+          Reflector,
+        ],
+      }).compile();
+
+      service = module.get(RegistryService);
+    });
+
+    it('should be defined', () => {
+      expect(service).toBeDefined();
+    });
+
+    it('should call registerResources, registerPrompts, registerTools in registerAll', async () => {
+      const server = {
+        resource: jest.fn(),
+        prompt: jest.fn(),
+        tool: jest.fn(),
+      } as unknown as McpServer;
+
+      const spyRes = jest
+        .spyOn(service as any, 'registerResources')
+        .mockImplementation(() => {});
+
+      const spyPro = jest
+        .spyOn(service as any, 'registerPrompts')
+        .mockImplementation(() => {});
+
+      const spyTool = jest
+        .spyOn(service as any, 'registerTools')
+        .mockImplementation(() => {});
+
+      await service.registerAll(server);
+
+      expect(spyRes).toHaveBeenCalledWith(server);
+      expect(spyPro).toHaveBeenCalledWith(server);
+      expect(spyTool).toHaveBeenCalledWith(server);
+    });
+  });
+
+  describe('unit tests for private logic', () => {
+    let mockDiscovery: DiscoveryService;
+    let mockLogger: McpLoggerService;
+    let mockReflector: Reflector;
+    let mockSession: SessionManager;
+
+    beforeEach(() => {
+      mockDiscovery = {
+        getAllMethodsWithMetadata: jest.fn(),
+      } as unknown as DiscoveryService;
+      mockLogger = {
+        log: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+      } as unknown as McpLoggerService;
+      mockReflector = {
+        get: jest.fn(),
+        has: jest.fn(),
+        hasMetadata: jest.fn(),
+      } as unknown as Reflector;
+      mockSession = {
+        getSession: jest.fn(),
+        setSession: jest.fn(),
+        deleteSession: jest.fn(),
+      } as unknown as SessionManager;
+      service = new RegistryService(
+        mockDiscovery,
+        mockLogger,
+        mockReflector,
+        mockSession,
+      );
+    });
+
+    it('should throw if wrappedHandler is called on non-resolver', async () => {
+      const handler = jest.fn();
+      const instance = { constructor: () => {} };
+
+      // Mock Reflect.hasMetadata (used inside RegistryService)
+      jest.spyOn(Reflect, 'hasMetadata').mockReturnValue(false);
+
+      await expect(
+        service['wrappedHandler'](instance, handler, [{}]),
+      ).rejects.toThrow(/must be decorated with @Resolver/);
+    });
+
+    it('should throw UnauthorizedException if sessionId is missing', async () => {
+      const handler = jest.fn();
+      const instance = { constructor: { name: 'TestResolver' } };
+
+      // Mock Reflect.hasMetadata to return true for MCP_RESOLVER
+      jest.spyOn(Reflect, 'hasMetadata').mockReturnValue(true);
+
+      await expect(
+        service['wrappedHandler'](instance, handler, [{}]),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should throw ForbiddenException if session not found', async () => {
+      const handler = jest.fn();
+      const instance = { constructor: { name: 'TestResolver' } };
+
+      // Mock Reflect.hasMetadata to return true for MCP_RESOLVER
+      jest.spyOn(Reflect, 'hasMetadata').mockReturnValue(true);
+
+      (mockSession.getSession as jest.Mock).mockReturnValue(undefined);
+
+      await expect(
+        service['wrappedHandler'](instance, handler, [
+          { sessionId: 'notfound' },
+        ]),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should successfully execute the handler when everything is valid', async () => {
+      const handler = jest
+        .fn<string, [Record<string, unknown>]>()
+        .mockReturnValue('success');
+      const instance = { constructor: { name: 'TestResolver' } };
+      const sessionId = 'valid-session';
+      const extra = { sessionId };
+
+      // Mock Reflect.hasMetadata to return true for MCP_RESOLVER
+      jest.spyOn(Reflect, 'hasMetadata').mockReturnValue(true);
+
+      (mockSession.getSession as jest.Mock).mockReturnValue({
+        request: { headers: { 'x-test': 'value' }, body: { key: 'value' } },
+      });
+
+      // Mock runGuards to resolve successfully
+      jest.spyOn(service as any, 'runGuards').mockResolvedValue(undefined);
+
+      const result = await service['wrappedHandler'](instance, handler, [
+        extra,
+      ] as unknown[]);
+
+      expect(result).toBe('success');
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId,
+          headers: { 'x-test': 'value' },
+          body: { key: 'value' },
+        }),
+      );
+      expect(service['runGuards']).toHaveBeenCalled();
+    });
+
+    it('runGuards should resolve if no guards', async () => {
+      const instance = { constructor: () => {} };
+      const methodName = 'someMethod';
+      const sessionId = 'abc';
+      const request: unknown = {};
+      const args: unknown[] = [];
+
+      await expect(
+        service['runGuards'](
+          instance,
+          methodName,
+          sessionId,
+          request as any,
+          args,
+        ),
+      ).resolves.toBeUndefined();
+    });
+
+    it('runGuards should throw if guard denies access', async () => {
+      const instance = { constructor: () => {} };
+      const methodName = 'someMethod';
+      const sessionId = 'abc';
+      const request: unknown = {};
+      const args: unknown[] = [];
+      const guard = { canActivate: jest.fn().mockResolvedValue(false) };
+
+      // Mock Reflect.getMetadata to return the guard
+      jest.spyOn(Reflect, 'getMetadata').mockReturnValue([guard]);
+
+      // Mock the private methods that are called inside runGuards
+      jest.spyOn(service as any, 'getDecoratorType').mockReturnValue('TOOL');
+      jest.spyOn(service as any, 'getHandlerArgs').mockReturnValue({
+        sessionId,
+        headers: {},
+        body: {},
+      });
+
+      await expect(
+        service['runGuards'](
+          instance,
+          methodName,
+          sessionId,
+          request as any,
+          args,
+        ),
+      ).rejects.toThrow(/Access denied by guard/);
+    });
+  });
+});

--- a/src/services/session.manager.spec.ts
+++ b/src/services/session.manager.spec.ts
@@ -1,0 +1,30 @@
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { Request } from 'express';
+import { SessionManager } from './session.manager';
+
+describe('SessionManager', () => {
+  let manager: SessionManager;
+
+  beforeEach(() => {
+    manager = new SessionManager();
+  });
+
+  it('should be defined', () => {
+    expect(manager).toBeDefined();
+  });
+
+  it('should set, get, and delete session', () => {
+    const session = {
+      transport: {} as StreamableHTTPServerTransport,
+      request: {} as Request,
+    };
+
+    manager.setSession('abc', session);
+
+    expect(manager.getSession('abc')).toBe(session);
+
+    manager.deleteSession('abc');
+
+    expect(manager.getSession('abc')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Changes:

- add unit tests to increase coverage to at least 50% of lines
- update coverage thresholds and ignore patterns in package.json


Closes #27 