### PR TITLE
ci(release): trigger patch on build(deps): and chore(deps): commits

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -10,7 +10,15 @@ module.exports = {
     { name: 'rc', prerelease: true },
   ],
   plugins: [
-    '@semantic-release/commit-analyzer',
+    [
+      '@semantic-release/commit-analyzer',
+      {
+        releaseRules: [
+          { type: 'build', scope: 'deps', release: 'patch' },
+          { type: 'chore', scope: 'deps', release: 'patch' },
+        ],
+      },
+    ],
     '@semantic-release/release-notes-generator',
     '@semantic-release/changelog',
     '@semantic-release/npm',


### PR DESCRIPTION
@semantic-release/commit-analyzer was using the default angular preset strictly, so build(deps): and chore(deps): commits were ignored even when they cleared security advisories visible to consumers — as happened with the dep bumps in #114.

Custom releaseRules now map both prefixes (scoped to deps only, not deps-dev) to a patch release. feat:/fix:/perf: defaults are unaffected.

Closes #116