### PR TITLE
feat!: add dynamic capabilities resolved per connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@
     - [Tool Annotations](#tool-annotations)
     - [ToolOptions Variants](#tooloptions-variants)
   - [RequestHandlerExtra Argument](#requesthandlerextra-argument)
+- [Dynamic Capabilities](#dynamic-capabilities)
+  - [Static toggle](#static-toggle)
+  - [Predicate toggle](#predicate-toggle)
+  - [What the client sees](#what-the-client-sees)
+  - [Rules you must know before using this](#rules-you-must-know-before-using-this)
+  - [This is not a replacement for guards](#this-is-not-a-replacement-for-guards)
 - [Guards](#guards)
   - [Global-level guards](#global-level-guards)
   - [Resolver-level guards](#resolver-level-guards)
@@ -600,6 +606,146 @@ export class AuthResolver {
 
 - `extra` is always the last parameter in any method decorated with `@Resource`, `@Prompt`, or `@Tool`
 - The `headers` property is an extension added by @nestjs-mcp/server to access HTTP headers directly
+
+---
+
+## Dynamic Capabilities
+
+`@Tool`, `@Prompt` and `@Resource` all accept an optional `enabled` option that decides, **per connection**, whether that capability is advertised and invocable.
+
+```ts
+type McpCapabilityToggle = boolean | Type<McpCapabilityGate>;
+
+interface McpCapabilityGate {
+  isEnabled(context: McpRegistrationContext): boolean | Promise<boolean>;
+}
+
+interface McpRegistrationContext {
+  /** The HTTP request that opened this connection. */
+  request: Request; // express
+  /** Validated token info, if auth middleware populated `req.auth`. */
+  authInfo?: AuthInfo; // @modelcontextprotocol/sdk/server/auth/types
+}
+```
+
+Two forms, one option key. Omitting `enabled` is the default and behaves exactly as it did before the option existed: always registered, always enabled, and it costs the connection nothing.
+
+### Static toggle
+
+For a capability that is simply off. It needs no class, no provider and no `await`.
+
+```ts
+@Tool({
+  name: 'legacy_tool',
+  description: 'Kept for compatibility, not offered to clients',
+  enabled: false,
+})
+legacyTool(): CallToolResult {
+  /* ... */
+}
+```
+
+### Capability gate
+
+For a decision the server has to make. A gate is a **class**, resolved from the Nest container exactly as a guard is — so it can inject services — and its verdict is **awaited**, so it can do real asynchronous work.
+
+```ts
+import { Injectable } from '@nestjs/common';
+import {
+  McpCapabilityGate,
+  McpRegistrationContext,
+  Resolver,
+  Tool,
+} from '@nestjs-mcp/server';
+
+@Injectable()
+export class AdminGate implements McpCapabilityGate {
+  constructor(private readonly permissions: PermissionsService) {}
+
+  // `authInfo` may be undefined — always optional-chain it.
+  async isEnabled(context: McpRegistrationContext): Promise<boolean> {
+    if (context.request.headers['x-role'] === 'admin') return true;
+
+    return this.permissions.isAdmin(context.authInfo?.clientId);
+  }
+}
+
+@Resolver('admin')
+export class AdminResolver {
+  @Tool({
+    name: 'rotate_keys',
+    description: 'Only advertised to admin connections',
+    enabled: AdminGate,
+  })
+  rotateKeys(): CallToolResult {
+    /* ... */
+  }
+}
+```
+
+Register the gate as a provider in the module that owns the resolver:
+
+```ts
+@Module({
+  imports: [McpModule.forRoot({ name: 'admin', version: '1.0.0' })],
+  providers: [PermissionsService, AdminGate, AdminResolver],
+})
+export class AppModule {}
+```
+
+Pass the **class**, never an instance — an instance built at module scope cannot reach the container, which is the whole reason the gate is a class. A gate may also answer synchronously (`isEnabled(): boolean`) when the check is a cheap in-memory one; `boolean | Promise<boolean>` covers both.
+
+Note that `McpRegistrationContext` carries **no `sessionId`**, deliberately. It exists under SSE at registration time but not under streamable HTTP, where the transport assigns it while handling the `initialize` POST — after registration has already run. Exposing it would make the same gate behave differently per transport.
+
+### What the client sees
+
+A disabled capability is **registered and then disabled**, never skipped. It is therefore absent from `tools/list` / `prompts/list` / `resources/list`, and invoking it answers `Tool <name> disabled` rather than `Tool <name> not found` — the two are distinct in the SDK and the first is the correct answer for a capability that exists but is off for you.
+
+### Fail-closed, in five cases
+
+A gate that cannot answer never leaves a capability exposed:
+
+| Case | Result |
+| --- | --- |
+| `isEnabled` throws synchronously | disabled, error logged |
+| `isEnabled` returns a **rejecting** promise | disabled, error logged |
+| the gate class cannot be resolved from the container | disabled, error logged — it is **never** silently built with `new`, because such a gate has `undefined` dependencies and could answer something accidentally truthy |
+| a gate is declared but no registration context exists | disabled, error logged |
+| `disable()` itself throws | the capability **remains enabled**, and the log says so — the one residual fail-open, because there is no other way to disable |
+
+A failing gate never affects the capabilities beside it, and never turns the connection into a 500. Log lines name the capability and the failure only — never the request, its headers, or a token.
+
+### Rules you must know before using this
+
+- **Evaluated once per connection.** A fresh MCP server is built for each client connection and `enabled` is resolved while it is being populated. The resulting capability set is frozen for the life of that connection; changing whatever the gate reads does not affect an already-connected client. A client sees a new decision only by reconnecting.
+- **No `listChanged` notification is emitted.** Every toggle is applied before the server is connected to its transport, where the SDK gates notification dispatch. This library never sends `notifications/tools/list_changed` or its prompt/resource equivalents. Do not expect a connected client to be told that something changed — nothing changes mid-session.
+- **Keep gates cheap — they run before `initialize` is answered.** Under streamable HTTP the server is built and registered *before* the transport answers the client's `initialize`, so every gate settles before the client is served. The library bounds the cost: registration itself stays synchronous, all gates settle in **one concurrency wave** (the added latency is the slowest single gate, not the sum), and each distinct gate class is resolved from the container **once per connection** however many capabilities share it. What it cannot bound is the gate itself. Upstream's guidance applies directly — *"connection pools and caches should be created at module scope to keep the factory cheap and side-effect-free"* — so do your caching in the injected service, at provider scope. There is **no built-in timeout**: a gate that never settles leaves `initialize` unanswered.
+- **A gate with no registration context fails closed.** Both built-in transports always pass a context. If you call `RegistryService.registerAll(server)` yourself with a single argument, any capability declaring a *gate* is disabled and the reason is logged. Static `true` / `false` and capabilities with no `enabled` option are unaffected.
+- **`authInfo` may be `undefined`.** It is only populated when auth middleware (for example the SDK's `requireBearerAuth`) ran before the MCP controller. Write `context.authInfo?.scopes` — a gate that dereferences it unguarded throws, and then fails closed, which silently removes the capability.
+- **Request-scoped gate providers are not supported.** A gate is resolved with `moduleRef.get(..., { strict: false })`, falling back to `moduleRef.create`. Neither handles a request-scoped provider cleanly. Use a singleton gate that reads what it needs from the registration context.
+
+### This is not a replacement for guards
+
+`enabled` is **discovery-level defence-in-depth**, not the authorization mechanism. [Guards](#guards) are: they run on every capability invocation, against that invocation's own context.
+
+The reason is concrete. Under streamable HTTP, the registration context is built from the `initialize` POST and nothing else — every later `tools/call` arrives on a *different* HTTP request whose `req.auth` is never consulted by this option. A permission that can be revoked, expire, or differ between calls within one session must be enforced by a guard on the capability itself.
+
+This is the same line the MCP SDK draws for its own per-request factory: the HTTP layer verifies the bearer token, while per-tool checks live in the handler, because *"the handler is the authoritative source for the executing tool."*
+
+Use `enabled` to decide what a connection should even see; use a guard to decide whether a call is allowed.
+
+### Migrating from `1.x`
+
+Two breaking changes, both narrow:
+
+| # | Break | Before | After |
+| --- | --- | --- | --- |
+| 1 | `RegistryService.registerAll` is async | `registry.registerAll(server);` | `await registry.registerAll(server);` — and the enclosing function becomes `async`. Only affects code calling it **directly**; using `McpModule` normally does not. |
+| 2 | inline predicates removed | `enabled: (ctx) => ctx.request.headers['x-role'] === 'admin'` | a class implementing `McpCapabilityGate`, registered as a provider, passed as `enabled: AdminGate` — which is also what unlocks `async` and dependency injection. |
+
+Everything else is unchanged. A server that declares no `enabled` option anywhere needs no changes at all and pays no runtime cost for this feature.
+
+> A runnable example lives in [`examples/dynamic/`](./examples/dynamic/) — `EXAMPLE=dynamic pnpm start:example`.
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,9 @@ This directory contains ready-to-use example MCP servers demonstrating how to us
 - **guards/**  
   Shows how to implement and use guards in MCP servers to control access to capabilities and resources. Demonstrates different guard patterns and how to apply them to protect specific MCP features.
 
+- **dynamic/**  
+  Shows the `enabled` option, which decides per connection whether a capability is advertised and invocable. Contains a statically disabled tool; `AdminGate`, a gate class with an **injected** `PermissionsService` answering **asynchronously** on the `x-role` request header; a slow gate sharing that same service; and the three fail-closed paths — a gate that throws, a gate whose promise rejects, and a gate class the container cannot resolve. Also gates a prompt and a resource, plus a statically disabled prompt and resource. Connect with `x-role: admin` to see `admin_only_tool`, `admin_only_prompt` and `admin_only_resource` appear in their lists.
+
 - **for-root-async/**  
   Example of asynchronous module configuration of the MCP module using `forRootAsync` and environment variables.
 

--- a/examples/dynamic/app.module.ts
+++ b/examples/dynamic/app.module.ts
@@ -1,0 +1,37 @@
+import { Module } from '@nestjs/common';
+
+import { McpModule } from '../../src/mcp.module';
+import {
+  AdminGate,
+  BetaGate,
+  RejectingGate,
+  ThrowingGate,
+} from './capability.gates';
+import { DynamicResolver } from './dynamic.resolver';
+import { PermissionsService } from './permissions.service';
+
+@Module({
+  imports: [
+    McpModule.forRoot({
+      name: 'dynamic',
+      version: '1.0.0',
+      logging: {
+        enabled: true,
+        level: 'verbose',
+      },
+    }),
+  ],
+  providers: [
+    // Gates are ordinary providers, resolved through the container exactly as
+    // guards are — which is what lets them inject `PermissionsService`.
+    PermissionsService,
+    AdminGate,
+    BetaGate,
+    RejectingGate,
+    ThrowingGate,
+    // `UnresolvableGate` is deliberately absent: it demonstrates the
+    // fail-closed path for a gate the container cannot build.
+    DynamicResolver,
+  ],
+})
+export class AppModule {}

--- a/examples/dynamic/capability.gates.ts
+++ b/examples/dynamic/capability.gates.ts
@@ -1,0 +1,86 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { McpCapabilityGate, McpRegistrationContext } from '../../src';
+import { PermissionsService } from './permissions.service';
+
+/**
+ * The shape this feature exists for: a gate class with an **injected service**,
+ * answering **asynchronously**, evaluated once while this connection's server
+ * is being populated.
+ *
+ * It decides what this connection may discover — it is not an authorization
+ * check. Use `@UseGuards` for that: guards run on every invocation, against
+ * that invocation's own context.
+ *
+ * `authInfo` is only populated when auth middleware ran before the MCP
+ * controller, so it is always optional-chained.
+ */
+@Injectable()
+export class AdminGate implements McpCapabilityGate {
+  constructor(private readonly permissions: PermissionsService) {}
+
+  isEnabled(context: McpRegistrationContext): Promise<boolean> {
+    const role = context.request.headers['x-role'];
+
+    return this.permissions.isAdmin(
+      typeof role === 'string' ? role : undefined,
+      context.authInfo?.clientId,
+    );
+  }
+}
+
+/**
+ * A deliberately slow gate. With `AdminGate` it demonstrates the cost contract:
+ * every gate settles in one concurrency wave, so a connection pays the slowest
+ * single gate rather than the sum of them.
+ */
+@Injectable()
+export class BetaGate implements McpCapabilityGate {
+  constructor(private readonly permissions: PermissionsService) {}
+
+  isEnabled(): Promise<boolean> {
+    return this.permissions.isBetaEnabled();
+  }
+}
+
+/**
+ * A gate whose promise **rejects**. Fails closed — a distinct code path from a
+ * synchronous throw, and the one a naive `try { gate.isEnabled(ctx) } catch`
+ * misses entirely.
+ */
+@Injectable()
+export class RejectingGate implements McpCapabilityGate {
+  isEnabled(): Promise<boolean> {
+    return Promise.reject(
+      new Error('entitlements lookup timed out for this connection'),
+    );
+  }
+}
+
+/** A gate that throws synchronously. Fails closed. */
+@Injectable()
+export class ThrowingGate implements McpCapabilityGate {
+  isEnabled(): boolean {
+    throw new Error('entitlements service unreachable');
+  }
+}
+
+/**
+ * Registered in **no** module, and depending on a token nothing provides — so
+ * neither `moduleRef.get` nor `moduleRef.create` can build it.
+ *
+ * Fails closed, and is never instantiated with `new`: a `new`-built gate has
+ * `undefined` dependencies and could answer something accidentally truthy,
+ * which would be a fail-**open**.
+ */
+@Injectable()
+export class UnresolvableGate implements McpCapabilityGate {
+  constructor(
+    @Inject('ENTITLEMENTS_CLIENT')
+    private readonly client: { allowed: boolean },
+  ) {}
+
+  isEnabled(): boolean {
+    return this.client.allowed;
+  }
+}

--- a/examples/dynamic/dynamic.resolver.ts
+++ b/examples/dynamic/dynamic.resolver.ts
@@ -1,0 +1,216 @@
+import {
+  CallToolResult,
+  GetPromptResult,
+  ReadResourceResult,
+} from '@modelcontextprotocol/sdk/types';
+import { z } from 'zod';
+
+import {
+  Prompt,
+  RequestHandlerExtra,
+  Resolver,
+  Resource,
+  Tool,
+} from '../../src';
+import {
+  AdminGate,
+  BetaGate,
+  RejectingGate,
+  ThrowingGate,
+  UnresolvableGate,
+} from './capability.gates';
+
+const SearchParams = { query: z.string() };
+type SearchParamsType = typeof SearchParams;
+
+@Resolver('dynamic')
+export class DynamicResolver {
+  /**
+   * Control: no `enabled` option at all. Behaves exactly as it did before the
+   * option existed — always registered, always enabled, and it costs the
+   * connection no container lookup and no awaited work.
+   */
+  @Tool({
+    name: 'public_tool',
+    description: 'Always available, on every connection',
+  })
+  publicTool(_extra: RequestHandlerExtra): CallToolResult {
+    return { content: [{ type: 'text', text: 'public_tool' }] };
+  }
+
+  /**
+   * Static toggle. Registered and then disabled, so calling it answers
+   * "Tool always_off_tool disabled" rather than "not found". Needs no gate
+   * class, no provider and no `await`.
+   */
+  @Tool({
+    name: 'always_off_tool',
+    description: 'Disabled for every connection',
+    enabled: false,
+  })
+  alwaysOffTool(_extra: RequestHandlerExtra): CallToolResult {
+    return { content: [{ type: 'text', text: 'always_off_tool' }] };
+  }
+
+  /**
+   * The headline case: a gate class with an **injected service**, answering
+   * **asynchronously**. Connect with `x-role: admin` and this tool appears in
+   * `tools/list`; connect without it and it does not.
+   */
+  @Tool({
+    name: 'admin_only_tool',
+    description: 'Only advertised to connections that look like an admin',
+    paramsSchema: SearchParams,
+    enabled: AdminGate,
+  })
+  adminOnlyTool(
+    params: SearchParamsType,
+    _extra: RequestHandlerExtra,
+  ): CallToolResult {
+    return {
+      content: [
+        { type: 'text', text: `admin_only_tool: ${JSON.stringify(params)}` },
+      ],
+    };
+  }
+
+  /**
+   * A slow gate, sharing `PermissionsService` with `AdminGate`. Both settle in
+   * the same concurrency wave, so the connection pays the slowest gate rather
+   * than the sum — and `PermissionsService` is resolved from the container
+   * once per connection, not once per capability.
+   */
+  @Tool({
+    name: 'beta_tool',
+    description: 'Gated on a deliberately slow lookup',
+    enabled: BetaGate,
+  })
+  betaTool(_extra: RequestHandlerExtra): CallToolResult {
+    return { content: [{ type: 'text', text: 'beta_tool' }] };
+  }
+
+  /**
+   * A gate that throws synchronously. Fails **closed** — disabled, logged, and
+   * every other capability still registers.
+   */
+  @Tool({
+    name: 'throwing_gate_tool',
+    description: 'Its gate throws, so it is never available',
+    enabled: ThrowingGate,
+  })
+  throwingGateTool(_extra: RequestHandlerExtra): CallToolResult {
+    return { content: [{ type: 'text', text: 'throwing_gate_tool' }] };
+  }
+
+  /**
+   * A gate whose promise **rejects**. A different code path from the throw
+   * above, and equally fail-closed.
+   */
+  @Tool({
+    name: 'rejecting_gate_tool',
+    description: 'Its gate rejects, so it is never available',
+    enabled: RejectingGate,
+  })
+  rejectingGateTool(_extra: RequestHandlerExtra): CallToolResult {
+    return { content: [{ type: 'text', text: 'rejecting_gate_tool' }] };
+  }
+
+  /**
+   * A gate class the container cannot resolve — it is in no module's
+   * `providers` and depends on a token nothing provides. Fails **closed**, and
+   * the log line names the capability and the gate so the cause is findable.
+   */
+  @Tool({
+    name: 'unresolvable_gate_tool',
+    description: 'Its gate cannot be resolved, so it is never available',
+    enabled: UnresolvableGate,
+  })
+  unresolvableGateTool(_extra: RequestHandlerExtra): CallToolResult {
+    return { content: [{ type: 'text', text: 'unresolvable_gate_tool' }] };
+  }
+
+  /** Control prompt: no `enabled` option. */
+  @Prompt({
+    name: 'public_prompt',
+    description: 'Always available',
+  })
+  publicPrompt(): GetPromptResult {
+    return {
+      messages: [
+        {
+          role: 'assistant',
+          content: { type: 'text', text: 'Anyone may read this prompt.' },
+        },
+      ],
+    };
+  }
+
+  /** Prompts honour the toggle through their own registration path. */
+  @Prompt({
+    name: 'always_off_prompt',
+    description: 'Disabled for every connection',
+    enabled: false,
+  })
+  alwaysOffPrompt(): GetPromptResult {
+    return {
+      messages: [
+        {
+          role: 'assistant',
+          content: { type: 'text', text: 'Nobody should ever read this.' },
+        },
+      ],
+    };
+  }
+
+  /** Prompts accept a gate class too, not only a static toggle. */
+  @Prompt({
+    name: 'admin_only_prompt',
+    description: 'Only advertised to connections that look like an admin',
+    enabled: AdminGate,
+  })
+  adminOnlyPrompt(): GetPromptResult {
+    return {
+      messages: [
+        {
+          role: 'assistant',
+          content: { type: 'text', text: 'Admin-only prompt.' },
+        },
+      ],
+    };
+  }
+
+  /** Control resource: no `enabled` option. */
+  @Resource({
+    name: 'public_resource',
+    uri: 'dynamic://public',
+  })
+  publicResource(uri: URL): ReadResourceResult {
+    return {
+      contents: [{ uri: uri.href, text: 'Anyone may read this resource.' }],
+    };
+  }
+
+  /** Resources honour the toggle through their own registration path. */
+  @Resource({
+    name: 'always_off_resource',
+    uri: 'dynamic://secret',
+    enabled: false,
+  })
+  alwaysOffResource(uri: URL): ReadResourceResult {
+    return {
+      contents: [{ uri: uri.href, text: 'Nobody should ever read this.' }],
+    };
+  }
+
+  /** Resources accept a gate class too. */
+  @Resource({
+    name: 'admin_only_resource',
+    uri: 'dynamic://admin',
+    enabled: AdminGate,
+  })
+  adminOnlyResource(uri: URL): ReadResourceResult {
+    return {
+      contents: [{ uri: uri.href, text: 'Admin-only resource.' }],
+    };
+  }
+}

--- a/examples/dynamic/main.ts
+++ b/examples/dynamic/main.ts
@@ -1,0 +1,19 @@
+import { NestFactory } from '@nestjs/core';
+
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+  console.log('Dynamic capabilities example running on http://localhost:3000');
+  console.log(
+    'Connect with header "x-role: admin" to see admin_only_tool, ' +
+      'admin_only_prompt and admin_only_resource appear in their lists.',
+  );
+  console.log(
+    'Without it, AdminGate consults PermissionsService through DI and answers ' +
+      'false. The throwing, rejecting and unresolvable gates always fail closed.',
+  );
+}
+
+void bootstrap();

--- a/examples/dynamic/permissions.service.ts
+++ b/examples/dynamic/permissions.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+
+/**
+ * Stands in for whatever a real deployment asks: a database, an entitlements
+ * API, a feature-flag service.
+ *
+ * A gate is resolved from the Nest container, so it can inject this. That is
+ * the whole point of the gate being a class: a bare lambda evaluated at
+ * class-definition time could never reach it.
+ *
+ * It is deliberately `async` — the answer arrives on a later tick, exactly as a
+ * real lookup would.
+ */
+@Injectable()
+export class PermissionsService {
+  private readonly adminClients = new Set(['admin-client']);
+
+  /** Simulates the latency of a real lookup, on the connect path. */
+  private static delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  async isAdmin(role?: string, clientId?: string): Promise<boolean> {
+    await PermissionsService.delay(10);
+
+    console.log(
+      `[PermissionsService] consulted for role=${role ?? 'none'} clientId=${clientId ?? 'none'}`,
+    );
+
+    return role === 'admin' || (!!clientId && this.adminClients.has(clientId));
+  }
+
+  /** A slow answer, to show that gates settle in one wave, not N round-trips. */
+  async isBetaEnabled(): Promise<boolean> {
+    await PermissionsService.delay(100);
+
+    return true;
+  }
+}

--- a/src/decorators/enabled-option.spec.ts
+++ b/src/decorators/enabled-option.spec.ts
@@ -1,0 +1,190 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/unbound-method */
+import { CallToolResult } from '@modelcontextprotocol/sdk/types';
+import { Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { z } from 'zod';
+
+import {
+  MCP_PROMPT,
+  MCP_RESOURCE,
+  MCP_TOOL,
+  McpCapabilityGate,
+  McpCapabilityToggle,
+  McpRegistrationContext,
+  Prompt,
+  Resolver,
+  Resource,
+  Tool,
+} from '../index';
+
+/**
+ * Consumer call site for the `enabled` capability gate.
+ *
+ * Everything here is imported from the package root exactly as a published
+ * consumer would import it. If a symbol used below is not exported from
+ * `src/index.ts`, this file fails to compile.
+ */
+
+/** The injected dependency a bare lambda could never have reached. */
+@Injectable()
+class PermissionsService {
+  isAdmin(clientId?: string): Promise<boolean> {
+    return Promise.resolve(clientId === 'admin-client');
+  }
+}
+
+/** The shape the redesign exists for: a class, injected, answering async. */
+@Injectable()
+class AdminGate implements McpCapabilityGate {
+  constructor(private readonly permissions: PermissionsService) {}
+
+  async isEnabled(context: McpRegistrationContext): Promise<boolean> {
+    if (context.request.headers['x-role'] === 'admin') return true;
+
+    return this.permissions.isAdmin(context.authInfo?.clientId);
+  }
+}
+
+/** A gate may still answer synchronously — `boolean | Promise<boolean>`. */
+@Injectable()
+class DebugGate implements McpCapabilityGate {
+  isEnabled(context: McpRegistrationContext): boolean {
+    return context.request.headers['x-debug'] === 'on';
+  }
+}
+
+/** Both members of the union are assignable to the exported toggle type. */
+const staticToggle: McpCapabilityToggle = false;
+const gateToggle: McpCapabilityToggle = AdminGate;
+
+@Resolver('dynamic')
+class DynamicResolver {
+  @Tool({ name: 'always_off_tool', enabled: false })
+  alwaysOffTool(): CallToolResult {
+    return { content: [{ type: 'text', text: 'off' }] };
+  }
+
+  @Tool({
+    name: 'gated_tool',
+    description: 'Only for admins',
+    paramsSchema: { id: z.string() },
+    enabled: AdminGate,
+  })
+  gatedTool(): CallToolResult {
+    return { content: [{ type: 'text', text: 'gated' }] };
+  }
+
+  @Tool({ name: 'debug_tool', enabled: DebugGate })
+  debugTool(): CallToolResult {
+    return { content: [{ type: 'text', text: 'debug' }] };
+  }
+
+  @Resource({
+    name: 'gated_resource',
+    uri: 'resource://example/secret',
+    enabled: AdminGate,
+  })
+  gatedResource() {
+    return { contents: [] };
+  }
+
+  @Prompt({ name: 'always_off_prompt', enabled: false })
+  alwaysOffPrompt() {
+    return { messages: [] };
+  }
+}
+
+const contextWith = (
+  headers: Record<string, string>,
+  clientId?: string,
+): McpRegistrationContext =>
+  ({
+    request: { headers },
+    authInfo: clientId
+      ? { token: 't', clientId, scopes: ['admin'] }
+      : undefined,
+  }) as unknown as McpRegistrationContext;
+
+describe('enabled capability gate (consumer call site)', () => {
+  let reflector: Reflector;
+
+  beforeEach(() => {
+    reflector = new Reflector();
+  });
+
+  it('carries a static "enabled" into @Tool metadata', () => {
+    const metadata = reflector.get(
+      MCP_TOOL,
+      DynamicResolver.prototype.alwaysOffTool,
+    );
+
+    expect(metadata).toEqual({
+      name: 'always_off_tool',
+      enabled: false,
+      methodName: 'alwaysOffTool',
+    });
+  });
+
+  it('carries a gate class "enabled" into @Tool metadata', () => {
+    const metadata = reflector.get(
+      MCP_TOOL,
+      DynamicResolver.prototype.gatedTool,
+    );
+
+    expect(metadata.name).toBe('gated_tool');
+    // The class reference itself travels through `SetMetadata`'s spread — the
+    // registry resolves it from the container, it is never called directly.
+    expect(metadata.enabled).toBe(AdminGate);
+  });
+
+  it('carries a gate class into @Resource metadata', () => {
+    const metadata = reflector.get(
+      MCP_RESOURCE,
+      DynamicResolver.prototype.gatedResource,
+    );
+
+    expect(metadata.name).toBe('gated_resource');
+    expect(metadata.enabled).toBe(AdminGate);
+  });
+
+  it('carries "enabled" into @Prompt metadata', () => {
+    const metadata = reflector.get(
+      MCP_PROMPT,
+      DynamicResolver.prototype.alwaysOffPrompt,
+    );
+
+    expect(metadata).toEqual({
+      name: 'always_off_prompt',
+      enabled: false,
+      methodName: 'alwaysOffPrompt',
+    });
+  });
+
+  it('accepts both members of McpCapabilityToggle', () => {
+    expect(staticToggle).toBe(false);
+    expect(gateToggle).toBe(AdminGate);
+  });
+
+  it('answers asynchronously from an injected dependency', async () => {
+    const gate = new AdminGate(new PermissionsService());
+
+    await expect(gate.isEnabled(contextWith({}, 'admin-client'))).resolves.toBe(
+      true,
+    );
+    await expect(gate.isEnabled(contextWith({}, 'other-client'))).resolves.toBe(
+      false,
+    );
+    await expect(
+      gate.isEnabled(contextWith({ 'x-role': 'admin' })),
+    ).resolves.toBe(true);
+  });
+
+  it('accepts a gate that answers synchronously', () => {
+    const gate = new DebugGate();
+
+    expect(gate.isEnabled(contextWith({ 'x-debug': 'on' }))).toBe(true);
+    expect(gate.isEnabled(contextWith({}))).toBe(false);
+  });
+});

--- a/src/decorators/prompt.decorator.spec.ts
+++ b/src/decorators/prompt.decorator.spec.ts
@@ -39,6 +39,11 @@ describe('Prompt Decorator', () => {
     methodComplete() {
       return { messages: [] };
     }
+
+    @Prompt({ name: 'prompt_disabled', enabled: false })
+    methodDisabled() {
+      return { messages: [] };
+    }
   }
 
   it('should set metadata for simple prompt', () => {
@@ -83,5 +88,25 @@ describe('Prompt Decorator', () => {
     expect(metadata.description).toBe('Complete prompt');
     expect(metadata.argsSchema).toBeDefined();
     expect(metadata.methodName).toBe('methodComplete');
+  });
+
+  it('should carry the enabled option into metadata', () => {
+    const metadata = reflector.get(
+      MCP_PROMPT,
+      TestResolver.prototype.methodDisabled,
+    );
+    expect(metadata).toEqual({
+      name: 'prompt_disabled',
+      enabled: false,
+      methodName: 'methodDisabled',
+    });
+  });
+
+  it('should not add an enabled key when the option is absent', () => {
+    const metadata = reflector.get(
+      MCP_PROMPT,
+      TestResolver.prototype.simpleMethod,
+    );
+    expect('enabled' in metadata).toBe(false);
   });
 });

--- a/src/decorators/prompt.decorator.ts
+++ b/src/decorators/prompt.decorator.ts
@@ -1,9 +1,15 @@
 import { SetMetadata } from '@nestjs/common';
 
+import type { McpCapabilityToggle } from '../interfaces/registration-context.interface';
 import { PromptArgsRawShape } from '../mcp.types';
 
 export interface PromptBaseOptions {
   name: string;
+  /**
+   * Whether this prompt is available to a connecting client.
+   * Evaluated once per connection; omit for the default (always enabled).
+   */
+  enabled?: McpCapabilityToggle;
 }
 
 export interface PromptWithDescriptionOptions extends PromptBaseOptions {

--- a/src/decorators/resource.decorator.spec.ts
+++ b/src/decorators/resource.decorator.spec.ts
@@ -38,6 +38,15 @@ describe('Resource Decorator', () => {
     templateWithMetadataMethod() {
       return { contents: [] };
     }
+
+    @Resource({
+      name: 'disabled_resource',
+      uri: 'resource://test/data',
+      enabled: false,
+    })
+    disabledMethod() {
+      return { contents: [] };
+    }
   }
 
   it('should set metadata for resource with URI', () => {
@@ -88,5 +97,26 @@ describe('Resource Decorator', () => {
       metadata: { version: '1.0' },
       methodName: 'templateWithMetadataMethod',
     });
+  });
+
+  it('should carry the enabled option into metadata', () => {
+    const metadata = reflector.get(
+      MCP_RESOURCE,
+      TestResolver.prototype.disabledMethod,
+    );
+    expect(metadata).toEqual({
+      name: 'disabled_resource',
+      uri: 'resource://test/data',
+      enabled: false,
+      methodName: 'disabledMethod',
+    });
+  });
+
+  it('should not add an enabled key when the option is absent', () => {
+    const metadata = reflector.get(
+      MCP_RESOURCE,
+      TestResolver.prototype.uriMethod,
+    );
+    expect('enabled' in metadata).toBe(false);
   });
 });

--- a/src/decorators/resource.decorator.ts
+++ b/src/decorators/resource.decorator.ts
@@ -1,7 +1,14 @@
 import { SetMetadata } from '@nestjs/common';
 
+import type { McpCapabilityToggle } from '../interfaces/registration-context.interface';
+
 export interface ResourceBaseOptions {
   name: string;
+  /**
+   * Whether this resource is available to a connecting client.
+   * Evaluated once per connection; omit for the default (always enabled).
+   */
+  enabled?: McpCapabilityToggle;
 }
 
 export interface ResourceUriOptions extends ResourceBaseOptions {

--- a/src/decorators/tool.decorator.spec.ts
+++ b/src/decorators/tool.decorator.spec.ts
@@ -47,6 +47,11 @@ describe('Tool Decorator', () => {
     methodWithAnnotations() {
       return { content: [{ type: 'text', text: 'test' }] };
     }
+
+    @Tool({ name: 'tool_disabled', enabled: false })
+    methodDisabled() {
+      return { content: [{ type: 'text', text: 'test' }] };
+    }
   }
 
   it('should set metadata for simple tool', () => {
@@ -104,5 +109,25 @@ describe('Tool Decorator', () => {
       readOnlyHint: true,
     });
     expect(metadata.methodName).toBe('methodWithAnnotations');
+  });
+
+  it('should carry the enabled option into metadata', () => {
+    const metadata = reflector.get(
+      MCP_TOOL,
+      TestResolver.prototype.methodDisabled,
+    );
+    expect(metadata).toEqual({
+      name: 'tool_disabled',
+      enabled: false,
+      methodName: 'methodDisabled',
+    });
+  });
+
+  it('should not add an enabled key when the option is absent', () => {
+    const metadata = reflector.get(
+      MCP_TOOL,
+      TestResolver.prototype.simpleMethod,
+    );
+    expect('enabled' in metadata).toBe(false);
   });
 });

--- a/src/decorators/tool.decorator.ts
+++ b/src/decorators/tool.decorator.ts
@@ -2,8 +2,15 @@ import { ToolAnnotations } from '@modelcontextprotocol/sdk/types';
 import { ZodRawShapeCompat } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import { SetMetadata } from '@nestjs/common';
 
+import type { McpCapabilityToggle } from '../interfaces/registration-context.interface';
+
 export interface ToolBaseOptions {
   name: string;
+  /**
+   * Whether this tool is available to a connecting client.
+   * Evaluated once per connection; omit for the default (always enabled).
+   */
+  enabled?: McpCapabilityToggle;
 }
 
 export interface ToolWithDescriptionOptions extends ToolBaseOptions {

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,1 +1,2 @@
 export * from './context.interface';
+export * from './registration-context.interface';

--- a/src/interfaces/registration-context.interface.ts
+++ b/src/interfaces/registration-context.interface.ts
@@ -1,0 +1,84 @@
+// Pulls in the SDK's own `express-serve-static-core` Request augmentation so
+// that `req.auth` is typed as `AuthInfo | undefined` across this package,
+// instead of re-declaring it here. Type-only: nothing is emitted at runtime.
+import type {} from '@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import type { Type } from '@nestjs/common';
+import type { Request } from 'express';
+
+/**
+ * Context available when a client connects and its `McpServer` is populated.
+ *
+ * A fresh `McpServer` is built per connection, so this context describes the
+ * single connection whose capabilities are being registered.
+ *
+ * Deliberately carries **no** `sessionId`: it exists under SSE at registration
+ * time but not under streamable HTTP, where the transport assigns it while
+ * handling the `initialize` POST — i.e. after registration has already run.
+ * Exposing it would make the same predicate behave differently per transport.
+ */
+export interface McpRegistrationContext {
+  /** The HTTP request that opened this connection. */
+  request: Request;
+
+  /**
+   * Validated token info, present only if auth middleware (for example the
+   * SDK's `requireBearerAuth`) populated `req.auth` before the MCP controller
+   * ran. Always guard with optional chaining.
+   */
+  authInfo?: AuthInfo;
+}
+
+/**
+ * Decides, once per connection, whether a capability is available to the
+ * connecting client.
+ *
+ * Resolved from the Nest container exactly as a guard is, so it may inject
+ * services and may answer asynchronously. Declare it as a class, never as an
+ * instance: an instance built at module scope cannot reach the container.
+ *
+ * Runs **before `initialize` is answered**, so keep it cheap and cache at
+ * provider scope (upstream guidance: `docs/serving/http.md` — "connection
+ * pools and caches should be created at module scope to keep the factory
+ * cheap and side-effect-free").
+ *
+ * Fails **closed** in every failure mode: a synchronous throw, a rejected
+ * promise, a class the container cannot resolve, and a gate declared when no
+ * registration context exists all disable the capability and log why.
+ *
+ * **This is discovery-level defence-in-depth, NOT authorization.**
+ * `@UseGuards` is the authorization mechanism: it runs on every invocation,
+ * against that invocation's own context. A gate runs once, when the
+ * connection is established. Under streamable HTTP its context is a snapshot
+ * of the `initialize` POST — every later `tools/call` arrives on a different
+ * HTTP request whose `req.auth` this mechanism never sees. Anything that can
+ * be revoked, expire, or differ per call must be enforced by a guard.
+ *
+ * @example
+ * ```typescript
+ * @Injectable()
+ * export class AdminOnlyGate implements McpCapabilityGate {
+ *   constructor(private readonly permissions: PermissionsService) {}
+ *
+ *   async isEnabled(context: McpRegistrationContext): Promise<boolean> {
+ *     return this.permissions.isAdmin(context.authInfo?.clientId);
+ *   }
+ * }
+ * ```
+ */
+export interface McpCapabilityGate {
+  isEnabled(context: McpRegistrationContext): boolean | Promise<boolean>;
+}
+
+/**
+ * The `enabled` option accepted by `@Tool`, `@Prompt` and `@Resource`.
+ *
+ * - absent / `true` — registered and enabled (the default). Costs nothing: no
+ *   container lookup and no `await`.
+ * - `false` — registered and then disabled, so the SDK answers
+ *   `<name> disabled` rather than `<name> not found`.
+ * - a {@link McpCapabilityGate} **class** — resolved from the Nest container
+ *   once per connection and awaited. See {@link McpCapabilityGate} for the
+ *   fail-closed contract and the gate-versus-guard boundary.
+ */
+export type McpCapabilityToggle = boolean | Type<McpCapabilityGate>;

--- a/src/services/registry.service.spec.ts
+++ b/src/services/registry.service.spec.ts
@@ -19,6 +19,10 @@ import {
   MCP_RESOURCE,
   MCP_TOOL,
 } from '../decorators';
+import type {
+  McpCapabilityGate,
+  McpRegistrationContext,
+} from '../interfaces/registration-context.interface';
 import { DiscoveryService } from './discovery.service';
 import { McpLoggerService } from './logger.service';
 import { RegistryService } from './registry.service';
@@ -54,7 +58,7 @@ describe('RegistryService', () => {
       expect(service).toBeDefined();
     });
 
-    it('should call registerResources, registerPrompts, registerTools in registerAll', () => {
+    it('should call registerResources, registerPrompts, registerTools in registerAll', async () => {
       const server = {
         resource: jest.fn(),
         prompt: jest.fn(),
@@ -63,21 +67,80 @@ describe('RegistryService', () => {
 
       const spyRes = jest
         .spyOn(service as any, 'registerResources')
-        .mockImplementation(() => {});
+        .mockResolvedValue(undefined);
 
       const spyPro = jest
         .spyOn(service as any, 'registerPrompts')
-        .mockImplementation(() => {});
+        .mockResolvedValue(undefined);
 
       const spyTool = jest
         .spyOn(service as any, 'registerTools')
-        .mockImplementation(() => {});
+        .mockResolvedValue(undefined);
 
-      service.registerAll(server);
+      await service.registerAll(server);
 
-      expect(spyRes).toHaveBeenCalledWith(server);
-      expect(spyPro).toHaveBeenCalledWith(server);
-      expect(spyTool).toHaveBeenCalledWith(server);
+      expect(spyRes).toHaveBeenCalledWith(server, undefined, expect.any(Array));
+      expect(spyPro).toHaveBeenCalledWith(server, undefined, expect.any(Array));
+      expect(spyTool).toHaveBeenCalledWith(
+        server,
+        undefined,
+        expect.any(Array),
+      );
+    });
+
+    it('should forward the registration context to every register method', async () => {
+      const server = {
+        resource: jest.fn(),
+        prompt: jest.fn(),
+        tool: jest.fn(),
+      } as unknown as McpServer;
+
+      const context = {
+        request: { headers: { 'x-role': 'admin' } },
+      } as unknown as McpRegistrationContext;
+
+      const spyRes = jest
+        .spyOn(service as any, 'registerResources')
+        .mockResolvedValue(undefined);
+
+      const spyPro = jest
+        .spyOn(service as any, 'registerPrompts')
+        .mockResolvedValue(undefined);
+
+      const spyTool = jest
+        .spyOn(service as any, 'registerTools')
+        .mockResolvedValue(undefined);
+
+      await service.registerAll(server, context);
+
+      expect(spyRes).toHaveBeenCalledWith(server, context, expect.any(Array));
+      expect(spyPro).toHaveBeenCalledWith(server, context, expect.any(Array));
+      expect(spyTool).toHaveBeenCalledWith(server, context, expect.any(Array));
+    });
+
+    it('should still accept a single argument and return a promise', async () => {
+      const server = {
+        resource: jest.fn(),
+        prompt: jest.fn(),
+        tool: jest.fn(),
+      } as unknown as McpServer;
+
+      jest
+        .spyOn(service as any, 'registerResources')
+        .mockResolvedValue(undefined);
+      jest
+        .spyOn(service as any, 'registerPrompts')
+        .mockResolvedValue(undefined);
+      jest.spyOn(service as any, 'registerTools').mockResolvedValue(undefined);
+
+      // This assertion was written at the old shape (`const result: void = …`)
+      // to prove the change was MINOR. It is kept, updated, as the proof that
+      // it is now MAJOR: `registerAll` returns a promise that must be awaited,
+      // and a consumer who ignores it holds an incomplete registration.
+      const result: Promise<void> = service.registerAll(server);
+
+      expect(result).toBeInstanceOf(Promise);
+      await expect(result).resolves.toBeUndefined();
     });
   });
 
@@ -266,7 +329,7 @@ describe('RegistryService', () => {
           .mockReturnValue(() => 'wrapped-result');
       });
 
-      it('should register a URI resource without metadata', () => {
+      it('should register a URI resource without metadata', async () => {
         mockResourceMethod = {
           metadata: { name: 'test-uri-resource', uri: 'https://example.com' },
           instance: mockInstance,
@@ -277,7 +340,11 @@ describe('RegistryService', () => {
           mockResourceMethod,
         ]);
 
-        service['registerResources'](mockServer as unknown as McpServer);
+        await service['registerResources'](
+          mockServer as unknown as McpServer,
+          undefined,
+          [],
+        );
 
         expect(mockLogger.log).toHaveBeenCalledWith(
           expect.stringContaining('test-uri-resource'),
@@ -290,7 +357,7 @@ describe('RegistryService', () => {
         );
       });
 
-      it('should register a URI resource with metadata', () => {
+      it('should register a URI resource with metadata', async () => {
         mockResourceMethod = {
           metadata: {
             name: 'test-uri-resource-with-meta',
@@ -305,7 +372,11 @@ describe('RegistryService', () => {
           mockResourceMethod,
         ]);
 
-        service['registerResources'](mockServer as unknown as McpServer);
+        await service['registerResources'](
+          mockServer as unknown as McpServer,
+          undefined,
+          [],
+        );
 
         expect(mockServer.resource).toHaveBeenCalledWith(
           'test-uri-resource-with-meta',
@@ -315,7 +386,7 @@ describe('RegistryService', () => {
         );
       });
 
-      it('should register a template resource without metadata', () => {
+      it('should register a template resource without metadata', async () => {
         mockResourceMethod = {
           metadata: {
             name: 'test-template-resource',
@@ -329,7 +400,11 @@ describe('RegistryService', () => {
           mockResourceMethod,
         ]);
 
-        service['registerResources'](mockServer as unknown as McpServer);
+        await service['registerResources'](
+          mockServer as unknown as McpServer,
+          undefined,
+          [],
+        );
 
         expect(mockServer.resource).toHaveBeenCalledWith(
           'test-template-resource',
@@ -338,7 +413,7 @@ describe('RegistryService', () => {
         );
       });
 
-      it('should register a template resource with metadata', () => {
+      it('should register a template resource with metadata', async () => {
         mockResourceMethod = {
           metadata: {
             name: 'test-template-resource-with-meta',
@@ -353,7 +428,11 @@ describe('RegistryService', () => {
           mockResourceMethod,
         ]);
 
-        service['registerResources'](mockServer as unknown as McpServer);
+        await service['registerResources'](
+          mockServer as unknown as McpServer,
+          undefined,
+          [],
+        );
 
         expect(mockServer.resource).toHaveBeenCalledWith(
           'test-template-resource-with-meta',
@@ -363,7 +442,7 @@ describe('RegistryService', () => {
         );
       });
 
-      it('should handle errors when registering resources', () => {
+      it('should handle errors when registering resources', async () => {
         mockResourceMethod = {
           metadata: { name: 'error-resource', uri: 'https://example.com' },
           instance: mockInstance,
@@ -381,7 +460,11 @@ describe('RegistryService', () => {
           throw testError;
         });
 
-        service['registerResources'](mockServer as unknown as McpServer);
+        await service['registerResources'](
+          mockServer as unknown as McpServer,
+          undefined,
+          [],
+        );
 
         expect(mockLogger.error).toHaveBeenCalledWith(
           expect.stringContaining('Error registering resource error-resource'),
@@ -410,7 +493,7 @@ describe('RegistryService', () => {
           .mockReturnValue(() => 'wrapped-result');
       });
 
-      it('should register a basic prompt', () => {
+      it('should register a basic prompt', async () => {
         mockPromptMethod = {
           metadata: { name: 'test-prompt' },
           instance: mockInstance,
@@ -421,7 +504,11 @@ describe('RegistryService', () => {
           mockPromptMethod,
         ]);
 
-        service['registerPrompts'](mockServer as unknown as McpServer);
+        await service['registerPrompts'](
+          mockServer as unknown as McpServer,
+          undefined,
+          [],
+        );
 
         expect(mockLogger.log).toHaveBeenCalledWith(
           expect.stringContaining('test-prompt'),
@@ -433,7 +520,7 @@ describe('RegistryService', () => {
         );
       });
 
-      it('should register a prompt with description', () => {
+      it('should register a prompt with description', async () => {
         mockPromptMethod = {
           metadata: {
             name: 'test-prompt-with-description',
@@ -447,7 +534,11 @@ describe('RegistryService', () => {
           mockPromptMethod,
         ]);
 
-        service['registerPrompts'](mockServer as unknown as McpServer);
+        await service['registerPrompts'](
+          mockServer as unknown as McpServer,
+          undefined,
+          [],
+        );
 
         expect(mockServer.prompt).toHaveBeenCalledWith(
           'test-prompt-with-description',
@@ -456,7 +547,7 @@ describe('RegistryService', () => {
         );
       });
 
-      it('should register a prompt with argsSchema', () => {
+      it('should register a prompt with argsSchema', async () => {
         mockPromptMethod = {
           metadata: {
             name: 'test-prompt-with-args',
@@ -470,7 +561,11 @@ describe('RegistryService', () => {
           mockPromptMethod,
         ]);
 
-        service['registerPrompts'](mockServer as unknown as McpServer);
+        await service['registerPrompts'](
+          mockServer as unknown as McpServer,
+          undefined,
+          [],
+        );
 
         expect(mockServer.prompt).toHaveBeenCalledWith(
           'test-prompt-with-args',
@@ -479,7 +574,7 @@ describe('RegistryService', () => {
         );
       });
 
-      it('should register a prompt with description and argsSchema', () => {
+      it('should register a prompt with description and argsSchema', async () => {
         mockPromptMethod = {
           metadata: {
             name: 'test-prompt-with-description-and-args',
@@ -494,7 +589,11 @@ describe('RegistryService', () => {
           mockPromptMethod,
         ]);
 
-        service['registerPrompts'](mockServer as unknown as McpServer);
+        await service['registerPrompts'](
+          mockServer as unknown as McpServer,
+          undefined,
+          [],
+        );
 
         expect(mockServer.prompt).toHaveBeenCalledWith(
           'test-prompt-with-description-and-args',
@@ -504,7 +603,7 @@ describe('RegistryService', () => {
         );
       });
 
-      it('should handle errors when registering prompts', () => {
+      it('should handle errors when registering prompts', async () => {
         mockPromptMethod = {
           metadata: { name: 'error-prompt' },
           instance: mockInstance,
@@ -522,7 +621,11 @@ describe('RegistryService', () => {
           throw testError;
         });
 
-        service['registerPrompts'](mockServer as unknown as McpServer);
+        await service['registerPrompts'](
+          mockServer as unknown as McpServer,
+          undefined,
+          [],
+        );
 
         expect(mockLogger.error).toHaveBeenCalledWith(
           expect.stringContaining('Error registering prompt error-prompt'),
@@ -551,7 +654,7 @@ describe('RegistryService', () => {
           .mockReturnValue(() => 'wrapped-result');
       });
 
-      it('should register a basic tool', () => {
+      it('should register a basic tool', async () => {
         mockToolMethod = {
           metadata: { name: 'test-tool' },
           instance: mockInstance,
@@ -562,7 +665,11 @@ describe('RegistryService', () => {
           mockToolMethod,
         ]);
 
-        service['registerTools'](mockServer as unknown as McpServer);
+        await service['registerTools'](
+          mockServer as unknown as McpServer,
+          undefined,
+          [],
+        );
 
         expect(mockLogger.log).toHaveBeenCalledWith(
           expect.stringContaining('test-tool'),
@@ -574,7 +681,7 @@ describe('RegistryService', () => {
         );
       });
 
-      it('should register a tool with description', () => {
+      it('should register a tool with description', async () => {
         mockToolMethod = {
           metadata: {
             name: 'test-tool-with-description',
@@ -588,7 +695,11 @@ describe('RegistryService', () => {
           mockToolMethod,
         ]);
 
-        service['registerTools'](mockServer as unknown as McpServer);
+        await service['registerTools'](
+          mockServer as unknown as McpServer,
+          undefined,
+          [],
+        );
 
         expect(mockServer.tool).toHaveBeenCalledWith(
           'test-tool-with-description',
@@ -597,7 +708,7 @@ describe('RegistryService', () => {
         );
       });
 
-      it('should register a tool with paramsSchema', () => {
+      it('should register a tool with paramsSchema', async () => {
         mockToolMethod = {
           metadata: {
             name: 'test-tool-with-params',
@@ -611,7 +722,11 @@ describe('RegistryService', () => {
           mockToolMethod,
         ]);
 
-        service['registerTools'](mockServer as unknown as McpServer);
+        await service['registerTools'](
+          mockServer as unknown as McpServer,
+          undefined,
+          [],
+        );
 
         expect(mockServer.tool).toHaveBeenCalledWith(
           'test-tool-with-params',
@@ -620,7 +735,7 @@ describe('RegistryService', () => {
         );
       });
 
-      it('should register a tool with annotations', () => {
+      it('should register a tool with annotations', async () => {
         mockToolMethod = {
           metadata: {
             name: 'test-tool-with-annotations',
@@ -634,7 +749,11 @@ describe('RegistryService', () => {
           mockToolMethod,
         ]);
 
-        service['registerTools'](mockServer as unknown as McpServer);
+        await service['registerTools'](
+          mockServer as unknown as McpServer,
+          undefined,
+          [],
+        );
 
         expect(mockServer.tool).toHaveBeenCalledWith(
           'test-tool-with-annotations',
@@ -643,7 +762,7 @@ describe('RegistryService', () => {
         );
       });
 
-      it('should register a tool with paramsSchema and description', () => {
+      it('should register a tool with paramsSchema and description', async () => {
         mockToolMethod = {
           metadata: {
             name: 'test-tool-with-params-and-description',
@@ -658,7 +777,11 @@ describe('RegistryService', () => {
           mockToolMethod,
         ]);
 
-        service['registerTools'](mockServer as unknown as McpServer);
+        await service['registerTools'](
+          mockServer as unknown as McpServer,
+          undefined,
+          [],
+        );
 
         expect(mockServer.tool).toHaveBeenCalledWith(
           'test-tool-with-params-and-description',
@@ -668,7 +791,7 @@ describe('RegistryService', () => {
         );
       });
 
-      it('should register a tool with annotations and description', () => {
+      it('should register a tool with annotations and description', async () => {
         mockToolMethod = {
           metadata: {
             name: 'test-tool-with-annotations-and-description',
@@ -683,7 +806,11 @@ describe('RegistryService', () => {
           mockToolMethod,
         ]);
 
-        service['registerTools'](mockServer as unknown as McpServer);
+        await service['registerTools'](
+          mockServer as unknown as McpServer,
+          undefined,
+          [],
+        );
 
         expect(mockServer.tool).toHaveBeenCalledWith(
           'test-tool-with-annotations-and-description',
@@ -693,7 +820,7 @@ describe('RegistryService', () => {
         );
       });
 
-      it('should register a tool with paramsSchema and annotations', () => {
+      it('should register a tool with paramsSchema and annotations', async () => {
         mockToolMethod = {
           metadata: {
             name: 'test-tool-with-params-and-annotations',
@@ -708,7 +835,11 @@ describe('RegistryService', () => {
           mockToolMethod,
         ]);
 
-        service['registerTools'](mockServer as unknown as McpServer);
+        await service['registerTools'](
+          mockServer as unknown as McpServer,
+          undefined,
+          [],
+        );
 
         expect(mockServer.tool).toHaveBeenCalledWith(
           'test-tool-with-params-and-annotations',
@@ -718,7 +849,7 @@ describe('RegistryService', () => {
         );
       });
 
-      it('should register a tool with paramsSchema, annotations, and description', () => {
+      it('should register a tool with paramsSchema, annotations, and description', async () => {
         mockToolMethod = {
           metadata: {
             name: 'test-tool-with-params-annotations-description',
@@ -734,7 +865,11 @@ describe('RegistryService', () => {
           mockToolMethod,
         ]);
 
-        service['registerTools'](mockServer as unknown as McpServer);
+        await service['registerTools'](
+          mockServer as unknown as McpServer,
+          undefined,
+          [],
+        );
 
         expect(mockServer.tool).toHaveBeenCalledWith(
           'test-tool-with-params-annotations-description',
@@ -745,7 +880,7 @@ describe('RegistryService', () => {
         );
       });
 
-      it('should handle errors when registering tools', () => {
+      it('should handle errors when registering tools', async () => {
         mockToolMethod = {
           metadata: { name: 'error-tool' },
           instance: mockInstance,
@@ -763,7 +898,11 @@ describe('RegistryService', () => {
           throw testError;
         });
 
-        service['registerTools'](mockServer as unknown as McpServer);
+        await service['registerTools'](
+          mockServer as unknown as McpServer,
+          undefined,
+          [],
+        );
 
         expect(mockLogger.error).toHaveBeenCalledWith(
           expect.stringContaining('Error registering tool error-tool'),
@@ -810,7 +949,11 @@ describe('RegistryService', () => {
           mockToolMethod,
         ]);
 
-        service['registerTools'](mockServer as unknown as McpServer);
+        await service['registerTools'](
+          mockServer as unknown as McpServer,
+          undefined,
+          [],
+        );
 
         expect(mockServer.tool).toHaveBeenCalledWith(
           'string-tool',
@@ -843,7 +986,11 @@ describe('RegistryService', () => {
           mockToolMethod,
         ]);
 
-        service['registerTools'](mockServer as unknown as McpServer);
+        await service['registerTools'](
+          mockServer as unknown as McpServer,
+          undefined,
+          [],
+        );
 
         expect(mockServer.tool).toHaveBeenCalledWith(
           'complex-tool',
@@ -874,7 +1021,11 @@ describe('RegistryService', () => {
           mockToolMethod,
         ]);
 
-        service['registerTools'](mockServer as unknown as McpServer);
+        await service['registerTools'](
+          mockServer as unknown as McpServer,
+          undefined,
+          [],
+        );
 
         expect(mockServer.tool).toHaveBeenCalledWith(
           'enum-tool',
@@ -912,7 +1063,11 @@ describe('RegistryService', () => {
           mockToolMethod,
         ]);
 
-        service['registerTools'](mockServer as unknown as McpServer);
+        await service['registerTools'](
+          mockServer as unknown as McpServer,
+          undefined,
+          [],
+        );
 
         expect(mockServer.tool).toHaveBeenCalledWith(
           'nested-tool',
@@ -1359,6 +1514,697 @@ describe('RegistryService', () => {
         });
         expect(mockModuleRef.create).toHaveBeenCalledWith(TestGuard);
         expect(result).toBe(createdGuard);
+      });
+    });
+  });
+
+  /**
+   * Capability gates: the `enabled` option resolved as a class through the Nest
+   * container, awaited once per connection.
+   *
+   * Every case goes through the public `registerAll`, because that is where the
+   * gate wave lives — the three register methods deliberately return before any
+   * gate has settled.
+   */
+  describe('capability gates', () => {
+    interface Handle {
+      enabled: boolean;
+      enable: jest.Mock;
+      disable: jest.Mock;
+      update: jest.Mock;
+      remove: jest.Mock;
+    }
+
+    const createHandle = (): Handle => ({
+      enabled: true,
+      enable: jest.fn(),
+      disable: jest.fn(),
+      update: jest.fn(),
+      remove: jest.fn(),
+    });
+
+    const discovered = (metadata: Record<string, unknown>): MockMethod => ({
+      metadata,
+      instance: { constructor: { name: 'DynamicResolver' } },
+      handler: jest.fn(),
+    });
+
+    const context = {
+      request: { headers: { 'x-role': 'admin' } },
+    } as unknown as McpRegistrationContext;
+
+    interface Harness {
+      service: RegistryService;
+      server: McpServer;
+      /** The SDK registration mocks, exposed so a test can set the handle. */
+      tool: jest.Mock;
+      prompt: jest.Mock;
+      resource: jest.Mock;
+      logger: { log: jest.Mock; error: jest.Mock; debug: jest.Mock };
+      moduleRef: { get: jest.Mock; create: jest.Mock };
+    }
+
+    const buildHarness = (
+      methods: {
+        tools?: MockMethod[];
+        prompts?: MockMethod[];
+        resources?: MockMethod[];
+      },
+      provided: [unknown, unknown][] = [],
+    ): Harness => {
+      const container = new Map<unknown, unknown>(provided);
+
+      const discovery = {
+        getAllMethodsWithMetadata: jest.fn((key: string) => {
+          if (key === MCP_TOOL) return methods.tools ?? [];
+          if (key === MCP_PROMPT) return methods.prompts ?? [];
+          if (key === MCP_RESOURCE) return methods.resources ?? [];
+          return [];
+        }),
+      };
+
+      const logger = { log: jest.fn(), error: jest.fn(), debug: jest.fn() };
+
+      const moduleRef = {
+        get: jest.fn((token: unknown) => {
+          if (container.has(token)) return container.get(token);
+          throw new Error('Nest could not find the provider');
+        }),
+        create: jest.fn(() => {
+          throw new Error('Nest could not create the instance');
+        }),
+      };
+
+      const service = new RegistryService(
+        discovery as unknown as DiscoveryService,
+        logger as unknown as McpLoggerService,
+        new Reflector(),
+        new SessionManager(),
+        moduleRef as unknown as ModuleRef,
+      );
+
+      jest
+        .spyOn(service as any, 'wrappedHandler')
+        .mockReturnValue(() => 'wrapped-result');
+
+      const tool = jest.fn();
+      const prompt = jest.fn();
+      const resource = jest.fn();
+      const server = { resource, prompt, tool };
+
+      return {
+        service,
+        server: server as unknown as McpServer,
+        tool,
+        prompt,
+        resource,
+        logger,
+        moduleRef,
+      };
+    };
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('resolves a gate class through ModuleRef and keeps the capability when it answers true', async () => {
+      class AllowGate implements McpCapabilityGate {
+        isEnabled(): Promise<boolean> {
+          return Promise.resolve(true);
+        }
+      }
+
+      const handle = createHandle();
+      const gate = new AllowGate();
+      const harness = buildHarness(
+        { tools: [discovered({ name: 'gated_tool', enabled: AllowGate })] },
+        [[AllowGate, gate]],
+      );
+      harness.tool.mockReturnValue(handle);
+
+      await harness.service.registerAll(harness.server, context);
+
+      expect(harness.moduleRef.get).toHaveBeenCalledWith(AllowGate, {
+        strict: false,
+      });
+      expect(handle.disable).not.toHaveBeenCalled();
+    });
+
+    it('disables a capability whose gate resolves false after a real tick', async () => {
+      class DeniedGate implements McpCapabilityGate {
+        isEnabled(): Promise<boolean> {
+          // A deferred promise, not Promise.resolve: a pending promise is
+          // truthy, so an implementation that skips the await passes with
+          // Promise.resolve and fails here.
+          return new Promise((resolve) => setTimeout(() => resolve(false), 5));
+        }
+      }
+
+      const handle = createHandle();
+      const harness = buildHarness(
+        { tools: [discovered({ name: 'gated_tool', enabled: DeniedGate })] },
+        [[DeniedGate, new DeniedGate()]],
+      );
+      harness.tool.mockReturnValue(handle);
+
+      await harness.service.registerAll(harness.server, context);
+
+      expect(handle.disable).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes the connection context to the gate', async () => {
+      const isEnabled = jest.fn().mockResolvedValue(true);
+      class ContextGate implements McpCapabilityGate {
+        isEnabled(ctx: McpRegistrationContext): Promise<boolean> {
+          return isEnabled(ctx) as Promise<boolean>;
+        }
+      }
+
+      const harness = buildHarness(
+        { tools: [discovered({ name: 'gated_tool', enabled: ContextGate })] },
+        [[ContextGate, new ContextGate()]],
+      );
+      harness.tool.mockReturnValue(createHandle());
+
+      await harness.service.registerAll(harness.server, context);
+
+      expect(isEnabled).toHaveBeenCalledTimes(1);
+      expect(isEnabled).toHaveBeenCalledWith(context);
+    });
+
+    it('has applied every gate verdict by the time registerAll resolves', async () => {
+      // The async-ordering backstop. A missed `await` inside registerAll is only
+      // an eslint warning, so nothing but this catches it.
+      let release!: (value: boolean) => void;
+      const deferred = new Promise<boolean>((resolve) => {
+        release = resolve;
+      });
+
+      class DeferredGate implements McpCapabilityGate {
+        isEnabled(): Promise<boolean> {
+          return deferred;
+        }
+      }
+
+      const handle = createHandle();
+      const harness = buildHarness(
+        { tools: [discovered({ name: 'gated_tool', enabled: DeferredGate })] },
+        [[DeferredGate, new DeferredGate()]],
+      );
+      harness.tool.mockReturnValue(handle);
+
+      const registration = harness.service.registerAll(harness.server, context);
+
+      expect(handle.disable).not.toHaveBeenCalled();
+
+      release(false);
+      await registration;
+
+      expect(handle.disable).toHaveBeenCalledTimes(1);
+    });
+
+    it('resolves each distinct gate class exactly once per connection', async () => {
+      const isEnabled = jest.fn().mockResolvedValue(true);
+      class SharedGate implements McpCapabilityGate {
+        isEnabled(): Promise<boolean> {
+          return isEnabled() as Promise<boolean>;
+        }
+      }
+
+      const harness = buildHarness(
+        {
+          tools: [
+            discovered({ name: 'tool_a', enabled: SharedGate }),
+            discovered({ name: 'tool_b', enabled: SharedGate }),
+            discovered({ name: 'tool_c', enabled: SharedGate }),
+          ],
+        },
+        [[SharedGate, new SharedGate()]],
+      );
+      harness.tool.mockReturnValue(createHandle());
+
+      await harness.service.registerAll(harness.server, context);
+
+      expect(harness.moduleRef.get).toHaveBeenCalledTimes(1);
+      expect(isEnabled).toHaveBeenCalledTimes(3);
+    });
+
+    it('evaluates gates in one concurrent wave, not N serial round-trips', async () => {
+      // Every gate must be in flight before any of them settles. A serial
+      // implementation never reaches the third arrival and fails by timeout.
+      const total = 3;
+      let arrived = 0;
+      let open!: () => void;
+      const allArrived = new Promise<void>((resolve) => {
+        open = resolve;
+      });
+
+      class BarrierGate implements McpCapabilityGate {
+        async isEnabled(): Promise<boolean> {
+          arrived += 1;
+          if (arrived === total) open();
+          await allArrived;
+          return true;
+        }
+      }
+
+      const harness = buildHarness(
+        {
+          tools: [
+            discovered({ name: 'tool_a', enabled: BarrierGate }),
+            discovered({ name: 'tool_b', enabled: BarrierGate }),
+            discovered({ name: 'tool_c', enabled: BarrierGate }),
+          ],
+        },
+        [[BarrierGate, new BarrierGate()]],
+      );
+      harness.tool.mockReturnValue(createHandle());
+
+      await harness.service.registerAll(harness.server, context);
+
+      expect(arrived).toBe(total);
+    });
+
+    it('falls back to ModuleRef.create when the gate is not a provider', async () => {
+      class CreatableGate implements McpCapabilityGate {
+        isEnabled(): boolean {
+          return true;
+        }
+      }
+
+      const handle = createHandle();
+      const harness = buildHarness({
+        tools: [discovered({ name: 'gated_tool', enabled: CreatableGate })],
+      });
+      harness.moduleRef.create.mockResolvedValue(new CreatableGate());
+      harness.tool.mockReturnValue(handle);
+
+      await harness.service.registerAll(harness.server, context);
+
+      expect(harness.moduleRef.create).toHaveBeenCalledWith(CreatableGate);
+      expect(handle.disable).not.toHaveBeenCalled();
+    });
+
+    describe('fail-closed', () => {
+      it('case 1: a gate that throws synchronously disables it, siblings untouched', async () => {
+        class ThrowingGate implements McpCapabilityGate {
+          isEnabled(): boolean {
+            throw new Error('entitlements service unreachable');
+          }
+        }
+
+        const gatedHandle = createHandle();
+        const siblingHandle = createHandle();
+        const harness = buildHarness(
+          {
+            tools: [
+              discovered({ name: 'throwing_tool', enabled: ThrowingGate }),
+              discovered({ name: 'sibling_tool' }),
+            ],
+          },
+          [[ThrowingGate, new ThrowingGate()]],
+        );
+        harness.tool
+          .mockReturnValueOnce(gatedHandle)
+          .mockReturnValueOnce(siblingHandle);
+
+        await harness.service.registerAll(harness.server, context);
+
+        expect(gatedHandle.disable).toHaveBeenCalledTimes(1);
+        expect(harness.logger.error).toHaveBeenCalledWith(
+          expect.stringContaining('throwing_tool'),
+          undefined,
+          'tools',
+        );
+        expect(siblingHandle.disable).not.toHaveBeenCalled();
+      });
+
+      it('case 2: a gate whose promise rejects disables it, siblings untouched', async () => {
+        class RejectingGate implements McpCapabilityGate {
+          isEnabled(): Promise<boolean> {
+            return Promise.reject(new Error('lookup timed out'));
+          }
+        }
+
+        const gatedHandle = createHandle();
+        const siblingHandle = createHandle();
+        const harness = buildHarness(
+          {
+            tools: [
+              discovered({ name: 'rejecting_tool', enabled: RejectingGate }),
+              discovered({ name: 'sibling_tool' }),
+            ],
+          },
+          [[RejectingGate, new RejectingGate()]],
+        );
+        harness.tool
+          .mockReturnValueOnce(gatedHandle)
+          .mockReturnValueOnce(siblingHandle);
+
+        // A try/catch around the call — instead of around the await — catches
+        // case 1 and misses this entirely, and an unhandled rejection would
+        // abort the whole Promise.all wave.
+        await expect(
+          harness.service.registerAll(harness.server, context),
+        ).resolves.toBeUndefined();
+
+        expect(gatedHandle.disable).toHaveBeenCalledTimes(1);
+        expect(harness.logger.error).toHaveBeenCalledWith(
+          expect.stringContaining('rejecting_tool'),
+          undefined,
+          'tools',
+        );
+        expect(siblingHandle.disable).not.toHaveBeenCalled();
+      });
+
+      it('case 3: an unresolvable gate class disables it and is never instantiated with new', async () => {
+        const constructed = jest.fn();
+
+        class UnresolvableGate implements McpCapabilityGate {
+          constructor() {
+            constructed();
+          }
+
+          isEnabled(): boolean {
+            return true;
+          }
+        }
+
+        const handle = createHandle();
+        const harness = buildHarness({
+          tools: [
+            discovered({ name: 'orphan_tool', enabled: UnresolvableGate }),
+          ],
+        });
+        harness.tool.mockReturnValue(handle);
+
+        await harness.service.registerAll(harness.server, context);
+
+        expect(handle.disable).toHaveBeenCalledTimes(1);
+        // `resolveGuard` falls back to `new Guard()`; a gate must not — a
+        // `new`-built gate has undefined dependencies and can answer truthy.
+        expect(constructed).not.toHaveBeenCalled();
+        expect(harness.logger.error).toHaveBeenCalledWith(
+          expect.stringContaining('orphan_tool'),
+          undefined,
+          'tools',
+        );
+      });
+
+      it('case 4: a gate declared with no registration context disables it', async () => {
+        class AnyGate implements McpCapabilityGate {
+          isEnabled(): boolean {
+            return true;
+          }
+        }
+
+        const handle = createHandle();
+        const harness = buildHarness(
+          {
+            tools: [discovered({ name: 'contextless_tool', enabled: AnyGate })],
+          },
+          [[AnyGate, new AnyGate()]],
+        );
+        harness.tool.mockReturnValue(handle);
+
+        await harness.service.registerAll(harness.server);
+
+        expect(handle.disable).toHaveBeenCalledTimes(1);
+        expect(harness.moduleRef.get).not.toHaveBeenCalled();
+        expect(harness.logger.error).toHaveBeenCalledWith(
+          expect.stringContaining('contextless_tool'),
+          undefined,
+          'tools',
+        );
+      });
+
+      it('case 5: a failing disable() leaves the capability enabled and says so', async () => {
+        const handle = createHandle();
+        handle.disable.mockImplementation(() => {
+          throw new Error('sdk exploded');
+        });
+
+        const harness = buildHarness({
+          tools: [discovered({ name: 'off_tool', enabled: false })],
+        });
+        harness.tool.mockReturnValue(handle);
+
+        await harness.service.registerAll(harness.server, context);
+
+        expect(harness.logger.error).toHaveBeenCalledWith(
+          expect.stringContaining('Failed to disable tool "off_tool"'),
+          undefined,
+          'tools',
+        );
+        expect(harness.logger.error).not.toHaveBeenCalledWith(
+          expect.stringContaining('Error registering tool'),
+          undefined,
+          'tools',
+        );
+      });
+
+      it('treats a non-boolean answer as disabled', async () => {
+        class SloppyGate implements McpCapabilityGate {
+          isEnabled(): boolean {
+            return 'yes' as unknown as boolean;
+          }
+        }
+
+        const handle = createHandle();
+        const harness = buildHarness(
+          { tools: [discovered({ name: 'sloppy_tool', enabled: SloppyGate })] },
+          [[SloppyGate, new SloppyGate()]],
+        );
+        harness.tool.mockReturnValue(handle);
+
+        await harness.service.registerAll(harness.server, context);
+
+        expect(handle.disable).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('static toggles and the gate-free path', () => {
+      it('disables a static false without consulting the container', async () => {
+        const handle = createHandle();
+        const harness = buildHarness({
+          tools: [discovered({ name: 'off_tool', enabled: false })],
+        });
+        harness.tool.mockReturnValue(handle);
+
+        await harness.service.registerAll(harness.server, context);
+
+        // Register-then-disable, never skip-registration: the SDK must answer
+        // "Tool off_tool disabled", not "Tool off_tool not found".
+        expect(harness.tool).toHaveBeenCalledWith(
+          'off_tool',
+          expect.any(Function),
+        );
+        expect(handle.disable).toHaveBeenCalledTimes(1);
+        expect(harness.moduleRef.get).not.toHaveBeenCalled();
+        expect(harness.moduleRef.create).not.toHaveBeenCalled();
+      });
+
+      it('leaves a static true alone', async () => {
+        const handle = createHandle();
+        const harness = buildHarness({
+          tools: [discovered({ name: 'on_tool', enabled: true })],
+        });
+        harness.tool.mockReturnValue(handle);
+
+        await harness.service.registerAll(harness.server, context);
+
+        expect(handle.disable).not.toHaveBeenCalled();
+        expect(harness.moduleRef.get).not.toHaveBeenCalled();
+      });
+
+      it('performs zero container lookups when no capability declares a gate', async () => {
+        const handle = createHandle();
+        const harness = buildHarness({
+          tools: [discovered({ name: 'plain_tool' })],
+          prompts: [discovered({ name: 'plain_prompt', description: 'd' })],
+          resources: [
+            discovered({ name: 'plain_resource', uri: 'https://example.com' }),
+          ],
+        });
+        harness.tool.mockReturnValue(handle);
+        harness.prompt.mockReturnValue(handle);
+        harness.resource.mockReturnValue(handle);
+
+        await harness.service.registerAll(harness.server, context);
+
+        expect(handle.disable).not.toHaveBeenCalled();
+        expect(harness.moduleRef.get).not.toHaveBeenCalled();
+        expect(harness.moduleRef.create).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('prompts and resources honour a gate', () => {
+      class DenyGate implements McpCapabilityGate {
+        isEnabled(): Promise<boolean> {
+          return Promise.resolve(false);
+        }
+      }
+
+      it('disables a prompt whose gate answers false', async () => {
+        const handle = createHandle();
+        const harness = buildHarness(
+          {
+            prompts: [
+              discovered({
+                name: 'off_prompt',
+                description: 'd',
+                enabled: DenyGate,
+              }),
+            ],
+          },
+          [[DenyGate, new DenyGate()]],
+        );
+        harness.prompt.mockReturnValue(handle);
+
+        await harness.service.registerAll(harness.server, context);
+
+        expect(harness.prompt).toHaveBeenCalled();
+        expect(handle.disable).toHaveBeenCalledTimes(1);
+      });
+
+      it('disables a resource whose gate answers false', async () => {
+        const handle = createHandle();
+        const harness = buildHarness(
+          {
+            resources: [
+              discovered({
+                name: 'off_resource',
+                uri: 'https://example.com',
+                enabled: DenyGate,
+              }),
+            ],
+          },
+          [[DenyGate, new DenyGate()]],
+        );
+        harness.resource.mockReturnValue(handle);
+
+        await harness.service.registerAll(harness.server, context);
+
+        expect(harness.resource).toHaveBeenCalled();
+        expect(handle.disable).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    /**
+     * Every registration branch must bind the handle it returns. A branch that
+     * drops the assignment leaves that permutation silently un-gateable while
+     * still type-checking at the call site — the `let handle` declaration
+     * without `| undefined` is the compiler's half of this guarantee, and these
+     * cases are the runtime half.
+     */
+    describe('handle binding across every registration branch', () => {
+      it.each([
+        ['ToolBaseOptions', {}],
+        ['ToolWithDescriptionOptions', { description: 'd' }],
+        ['ToolWithParamsSchemaOptions', { paramsSchema: { a: 'schema' } }],
+        [
+          'ToolWithParamsSchemaAndDescriptionOptions',
+          { description: 'd', paramsSchema: { a: 'schema' } },
+        ],
+        ['ToolWithAnnotationsOptions', { annotations: { readOnlyHint: true } }],
+        [
+          'ToolWithAnnotationsAndDescriptionOptions',
+          { description: 'd', annotations: { readOnlyHint: true } },
+        ],
+        [
+          'ToolWithParamsSchemaAndAnnotationsOptions',
+          {
+            paramsSchema: { a: 'schema' },
+            annotations: { readOnlyHint: true },
+          },
+        ],
+        [
+          'ToolWithParamsSchemaAndAnnotationsAndDescriptionOptions',
+          {
+            description: 'd',
+            paramsSchema: { a: 'schema' },
+            annotations: { readOnlyHint: true },
+          },
+        ],
+      ])('binds the handle for %s', async (_name, extra) => {
+        const handle = createHandle();
+        const harness = buildHarness({
+          tools: [
+            discovered({ name: 'permutation_tool', enabled: false, ...extra }),
+          ],
+        });
+        harness.tool.mockReturnValue(handle);
+
+        await harness.service.registerAll(harness.server, context);
+
+        expect(handle.disable).toHaveBeenCalledTimes(1);
+      });
+
+      it.each([
+        [
+          'a URI resource without metadata',
+          { uri: 'https://example.com' },
+          ['off_resource', 'https://example.com'],
+        ],
+        [
+          'a URI resource with metadata',
+          { uri: 'https://example.com', metadata: { version: '1.0' } },
+          ['off_resource', 'https://example.com', { version: '1.0' }],
+        ],
+        [
+          'a template resource without metadata',
+          { template: 'resource://test/{id}' },
+          ['off_resource', expect.any(ResourceTemplate)],
+        ],
+        [
+          'a template resource with metadata',
+          { template: 'resource://test/{id}', metadata: { version: '1.0' } },
+          ['off_resource', expect.any(ResourceTemplate), { version: '1.0' }],
+        ],
+      ])('binds the handle for %s', async (_name, extra, expectedArgs) => {
+        const handle = createHandle();
+        const harness = buildHarness({
+          resources: [
+            discovered({ name: 'off_resource', enabled: false, ...extra }),
+          ],
+        });
+        harness.resource.mockReturnValue(handle);
+
+        await harness.service.registerAll(harness.server, context);
+
+        expect(harness.resource).toHaveBeenCalledWith(
+          ...expectedArgs,
+          expect.any(Function),
+        );
+        expect(handle.disable).toHaveBeenCalledTimes(1);
+      });
+
+      it('claims nothing was disabled when resource metadata matches no branch', async () => {
+        const handle = createHandle();
+        const harness = buildHarness({
+          resources: [
+            discovered({ name: 'malformed_resource', enabled: false }),
+          ],
+        });
+        harness.resource.mockReturnValue(handle);
+
+        await harness.service.registerAll(harness.server, context);
+
+        // Nothing was registered, so nothing can be disabled — and the loop
+        // must not claim otherwise.
+        expect(harness.resource).not.toHaveBeenCalled();
+        expect(handle.disable).not.toHaveBeenCalled();
+        expect(harness.logger.log).not.toHaveBeenCalledWith(
+          expect.stringContaining('disabled for this connection'),
+          'resources',
+        );
+        expect(harness.logger.error).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'Error registering resource malformed_resource',
+          ),
+          undefined,
+          'resources',
+        );
       });
     });
   });

--- a/src/services/registry.service.ts
+++ b/src/services/registry.service.ts
@@ -1,3 +1,9 @@
+import type {
+  RegisteredPrompt,
+  RegisteredResource,
+  RegisteredResourceTemplate,
+  RegisteredTool,
+} from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
   McpServer,
   ResourceTemplate,
@@ -22,11 +28,50 @@ import {
   ToolOptions,
 } from '../decorators';
 import { McpExecutionContext } from '../interfaces/context.interface';
+import type {
+  McpCapabilityGate,
+  McpCapabilityToggle,
+  McpRegistrationContext,
+} from '../interfaces/registration-context.interface';
 import { RequestHandlerExtra } from '../mcp.types';
 import type { McpHandlerArgs } from '../types/handler-args.types';
 import { DiscoveryService } from './discovery.service';
 import { McpLoggerService } from './logger.service';
 import { SessionManager } from './session.manager';
+
+/** The four SDK registration handles, all of which expose `disable()`. */
+type McpCapabilityHandle =
+  | RegisteredPrompt
+  | RegisteredResource
+  | RegisteredResourceTemplate
+  | RegisteredTool;
+
+/**
+ * A capability that is registered and whose gate has not been consulted yet.
+ *
+ * Registration is synchronous by design: every SDK call, and every `disable()`
+ * for a static `enabled: false`, completes before the first `await`. Anything
+ * gated by a class lands here instead and is settled in one concurrency wave
+ * once all three register methods have returned.
+ *
+ * The list is local to a `registerAll` call and released with it — no handle is
+ * retained beyond the call.
+ */
+interface PendingCapabilityGate {
+  handle: McpCapabilityHandle;
+  /** Capability label used in the log line, e.g. `Tool`. */
+  label: string;
+  name: string;
+  /** Logger context — `tools`, `prompts` or `resources`. */
+  scope: string;
+  Gate: Type<McpCapabilityGate>;
+}
+
+/** Memoises `resolveGate` for the life of one `registerAll` call. */
+type GateResolutionCache = Map<
+  Type<McpCapabilityGate>,
+  Promise<McpCapabilityGate | null>
+>;
 
 @Injectable()
 export class RegistryService {
@@ -38,15 +83,110 @@ export class RegistryService {
     private readonly moduleRef: ModuleRef,
   ) {}
 
-  registerAll(server: McpServer): void {
+  /**
+   * Registers every discovered MCP capability on a freshly built server.
+   *
+   * Resolves only once every capability gate has settled, so the caller may
+   * connect the server to its transport knowing the capability set is final.
+   *
+   * Registration itself is synchronous: all SDK calls, and every `disable()`
+   * for a static `enabled: false`, happen before the first `await`. Only
+   * capabilities gated by a {@link McpCapabilityGate} class are deferred, and
+   * they are settled in a **single** concurrency wave — the added connection
+   * latency is the slowest gate, not the sum of them. A server that declares
+   * no gate performs zero container lookups and zero awaited work.
+   *
+   * @param server The `McpServer` built for one client connection.
+   * @param context Optional connection context. Every gate is evaluated
+   * against it once, at registration time. Capabilities whose toggle resolves
+   * to `false` are registered and then disabled, so the SDK answers
+   * `<name> disabled` rather than `<name> not found`. A capability declaring a
+   * gate when no context was provided fails closed.
+   */
+  async registerAll(
+    server: McpServer,
+    context?: McpRegistrationContext,
+  ): Promise<void> {
     this.logger.log(
       'Starting registration of all MCP capabilities...',
       'registry',
     );
 
-    this.registerResources(server);
-    this.registerPrompts(server);
-    this.registerTools(server);
+    const pending: PendingCapabilityGate[] = [];
+
+    await this.registerResources(server, context, pending);
+    await this.registerPrompts(server, context, pending);
+    await this.registerTools(server, context, pending);
+
+    await this.settlePendingGates(pending, context);
+  }
+
+  /**
+   * Settles every deferred gate in one concurrency wave.
+   *
+   * Each evaluation is written so it can never reject, so `Promise.all` never
+   * short-circuits: one failing gate can neither abort the wave nor strip the
+   * capabilities beside it, and nothing escapes into the transport's
+   * `try/catch` to turn the connection into a 500.
+   */
+  private async settlePendingGates(
+    pending: PendingCapabilityGate[],
+    context: McpRegistrationContext | undefined,
+  ): Promise<void> {
+    if (!pending.length) return;
+
+    // Call-local: one resolution per distinct gate class per connection,
+    // released with the call.
+    const cache: GateResolutionCache = new Map();
+
+    await Promise.all(
+      pending.map(async (capability) => {
+        const enabled = await this.isCapabilityEnabled(
+          capability,
+          context,
+          cache,
+        );
+
+        if (!enabled) {
+          this.disableCapability(
+            capability.handle,
+            capability.label,
+            capability.name,
+            capability.scope,
+          );
+        }
+      }),
+    );
+  }
+
+  /**
+   * Resolves a capability gate class through the Nest container.
+   *
+   * Mirrors {@link resolveGuard} with one deliberate divergence: there is no
+   * `new Gate()` fallback. A gate built with `new` bypasses DI, leaving every
+   * injected field `undefined`, and such a gate either throws or returns
+   * something accidentally truthy — a fail-**open**, which this design forbids.
+   * `moduleRef.create` already covers a dependency-free class, so the third
+   * fallback would buy nothing and risk the one outcome that is unacceptable.
+   *
+   * Never rejects: `null` means "could not resolve", which the caller turns
+   * into a disabled capability plus a log line naming it.
+   */
+  private async resolveGate(
+    Gate: Type<McpCapabilityGate>,
+  ): Promise<McpCapabilityGate | null> {
+    try {
+      return this.moduleRef.get<McpCapabilityGate>(Gate, { strict: false });
+    } catch {
+      try {
+        return await this.moduleRef.create<McpCapabilityGate>(Gate);
+      } catch {
+        // Logged by the caller, which knows which capability is affected. One
+        // resolution can be shared by many capabilities, so logging here would
+        // name the gate but not the capability the consumer is looking for.
+        return null;
+      }
+    }
   }
 
   private getDecoratorType(method: Type<any> | undefined): string | null {
@@ -235,7 +375,164 @@ export class RegistryService {
     return handler(...(args as TArgs));
   }
 
-  private registerResources(server: McpServer) {
+  /**
+   * Applies a capability's `enabled` toggle at registration time.
+   *
+   * Synchronous on purpose — this is the hot path every capability walks:
+   *
+   * - absent / `true` — nothing happens, and nothing is deferred.
+   * - `false` — disabled immediately, with no container round-trip.
+   * - a gate class — deferred to the concurrency wave in `registerAll`.
+   *
+   * @param toggle The capability's `enabled` option, if it declared one.
+   * @param handle The SDK registration handle just bound for this capability.
+   * @param label Capability label used in the log line, e.g. `Tool`.
+   * @param name The capability name.
+   * @param scope Logger context — `tools`, `prompts` or `resources`.
+   * @param pending The `registerAll` call's list of deferred gates.
+   */
+  private applyCapabilityToggle(
+    toggle: McpCapabilityToggle | undefined,
+    handle: McpCapabilityHandle,
+    label: string,
+    name: string,
+    scope: string,
+    pending: PendingCapabilityGate[],
+  ): void {
+    if (toggle === undefined || toggle === true) return;
+
+    if (toggle === false) {
+      this.disableCapability(handle, label, name, scope);
+      return;
+    }
+
+    pending.push({ handle, label, name, scope, Gate: toggle });
+  }
+
+  /**
+   * Asks a capability's gate whether it is available to this connection.
+   *
+   * Fails **closed** on every failure mode, because failing open would silently
+   * expose a capability the consumer intended to gate:
+   *
+   * 1. `isEnabled` throws synchronously.
+   * 2. `isEnabled` returns a **rejecting** promise — a distinct path, which is
+   *    why the `try` wraps the `await` and not merely the call.
+   * 3. the gate class cannot be resolved from the container.
+   * 4. a gate is declared and no registration context exists.
+   *
+   * Never rejects, so the surrounding `Promise.all` can never short-circuit.
+   *
+   * @param capability The deferred capability and its gate class.
+   * @param context The connection context, absent when `registerAll` was
+   * called with a single argument.
+   * @param cache Per-call memo, so N capabilities sharing one gate class cost
+   * one container resolution.
+   */
+  private async isCapabilityEnabled(
+    capability: PendingCapabilityGate,
+    context: McpRegistrationContext | undefined,
+    cache: GateResolutionCache,
+  ): Promise<boolean> {
+    const { Gate, name, scope } = capability;
+
+    if (!context) {
+      this.logger.error(
+        `Disabling "${name}": its "enabled" gate requires a registration context and none was provided.`,
+        undefined,
+        scope,
+      );
+      return false;
+    }
+
+    let resolution = cache.get(Gate);
+
+    if (!resolution) {
+      resolution = this.resolveGate(Gate);
+      cache.set(Gate, resolution);
+    }
+
+    const gate = await resolution;
+
+    if (!gate) {
+      this.logger.error(
+        `Disabling "${name}": its "enabled" gate ${Gate.name} could not be resolved from the container. Register it as a provider.`,
+        undefined,
+        scope,
+      );
+      return false;
+    }
+
+    try {
+      // The await is inside the try on purpose: a rejected promise and a
+      // synchronous throw are different code paths, and wrapping only the call
+      // would catch the second and miss the first.
+      const verdict = await gate.isEnabled(context);
+
+      // Strict comparison, not truthiness: anything that is not exactly `true`
+      // — including a value a JavaScript caller slipped past the types — is
+      // treated as a denial rather than accidentally exposing the capability.
+      return verdict === true;
+    } catch (error) {
+      this.logger.error(
+        `Disabling "${name}": its "enabled" gate ${Gate.name} failed: ${error}`,
+        undefined,
+        scope,
+      );
+      return false;
+    }
+  }
+
+  /**
+   * Disables a capability whose `enabled` toggle resolved to `false`.
+   *
+   * The `disable()` call is isolated from the surrounding registration
+   * `try/catch` deliberately. If it threw there, the outer handler would log
+   * "Error registering <name>" and the capability would stay **enabled** —
+   * failing open, the exact inversion of the consumer's intent. Here the
+   * failure gets its own log line that says the capability is still exposed.
+   *
+   * @param handle The SDK registration handle returned by `server.tool` /
+   * `server.prompt` / `server.resource`.
+   * @param label Capability label used in the log line, e.g. `Tool`.
+   * @param name The capability name.
+   * @param scope Logger context — `tools`, `prompts` or `resources`.
+   */
+  private disableCapability(
+    handle: McpCapabilityHandle,
+    label: string,
+    name: string,
+    scope: string,
+  ): void {
+    try {
+      handle.disable();
+      this.logger.log(
+        `${label} "${name}" disabled for this connection.`,
+        scope,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to disable ${label.toLowerCase()} "${name}": it remains enabled for this connection. ${error}`,
+        undefined,
+        scope,
+      );
+    }
+  }
+
+  /**
+   * Returns `Promise<void>` but performs no awaited work, deliberately.
+   *
+   * Registration is synchronous by contract: every SDK call and every static
+   * `disable()` completes before `registerAll` reaches its first `await`, which
+   * keeps listing order deterministic and lets a gate-free server pay nothing.
+   * The promise return is the seam the gate wave hangs off — `registerAll`
+   * awaits these before settling `pending` — so it stays in the signature.
+   */
+  private registerResources(
+    server: McpServer,
+    context: McpRegistrationContext | undefined,
+    pending: PendingCapabilityGate[],
+  ): Promise<void> {
     const resourceMethods =
       this.discoveryService.getAllMethodsWithMetadata<ResourceOptions>(
         MCP_RESOURCE,
@@ -252,16 +549,25 @@ export class RegistryService {
         this.wrappedHandler(instance, handler, args);
 
       try {
+        // The handle is bound so the toggle can disable it, then released with
+        // the loop iteration. Retaining handles is out of scope by design.
+        //
+        // Declared without `| undefined` on purpose: the chain below is
+        // exhaustive, so dropping an assignment in any branch is a compile
+        // error (TS2454, "used before being assigned") instead of a silent
+        // no-op at `disable()` time.
+        let handle: RegisteredResource | RegisteredResourceTemplate;
+
         if ('template' in metadata) {
           if ('metadata' in metadata) {
-            server.resource(
+            handle = server.resource(
               metadata.name,
               new ResourceTemplate(metadata.template, { list: undefined }),
               metadata.metadata,
               wrappedHandler,
             );
           } else {
-            server.resource(
+            handle = server.resource(
               metadata.name,
               new ResourceTemplate(metadata.template, { list: undefined }),
               wrappedHandler,
@@ -269,16 +575,38 @@ export class RegistryService {
           }
         } else if ('uri' in metadata) {
           if ('metadata' in metadata) {
-            server.resource(
+            handle = server.resource(
               metadata.name,
               metadata.uri,
               metadata.metadata,
               wrappedHandler,
             );
           } else {
-            server.resource(metadata.name, metadata.uri, wrappedHandler);
+            handle = server.resource(
+              metadata.name,
+              metadata.uri,
+              wrappedHandler,
+            );
           }
+        } else {
+          // Unreachable through the typed API: every `ResourceOptions` member
+          // declares `uri` or `template`. The `never` assignment is the
+          // compile-time proof that the chain above is exhaustive, which is
+          // what lets `handle` be declared without `| undefined`.
+          const unhandled: never = metadata;
+          throw new Error(
+            `Resource metadata matched no registration branch: ${JSON.stringify(unhandled)}`,
+          );
         }
+
+        this.applyCapabilityToggle(
+          metadata.enabled,
+          handle,
+          'Resource',
+          metadata.name,
+          'resources',
+          pending,
+        );
       } catch (error) {
         this.logger.error(
           `Error registering resource ${metadata.name}: ${error}`,
@@ -294,9 +622,16 @@ export class RegistryService {
         }
       }
     }
+
+    return Promise.resolve();
   }
 
-  private registerPrompts(server: McpServer) {
+  /** Synchronous by contract — see {@link registerResources}. */
+  private registerPrompts(
+    server: McpServer,
+    context: McpRegistrationContext | undefined,
+    pending: PendingCapabilityGate[],
+  ): Promise<void> {
     const promptMethods =
       this.discoveryService.getAllMethodsWithMetadata<PromptOptions>(
         MCP_PROMPT,
@@ -313,20 +648,41 @@ export class RegistryService {
         this.wrappedHandler(instance, handler, args);
 
       try {
+        // The handle is bound so the toggle can disable it, then released with
+        // the loop iteration. Retaining handles is out of scope by design.
+        let handle: RegisteredPrompt;
+
         if ('description' in metadata && 'argsSchema' in metadata) {
-          server.prompt(
+          handle = server.prompt(
             metadata.name,
             metadata.description,
             metadata.argsSchema,
             wrappedHandler,
           );
         } else if ('argsSchema' in metadata) {
-          server.prompt(metadata.name, metadata.argsSchema, wrappedHandler);
+          handle = server.prompt(
+            metadata.name,
+            metadata.argsSchema,
+            wrappedHandler,
+          );
         } else if ('description' in metadata) {
-          server.prompt(metadata.name, metadata.description, wrappedHandler);
+          handle = server.prompt(
+            metadata.name,
+            metadata.description,
+            wrappedHandler,
+          );
         } else {
-          server.prompt(metadata.name, wrappedHandler);
+          handle = server.prompt(metadata.name, wrappedHandler);
         }
+
+        this.applyCapabilityToggle(
+          metadata.enabled,
+          handle,
+          'Prompt',
+          metadata.name,
+          'prompts',
+          pending,
+        );
       } catch (error) {
         this.logger.error(
           `Error registering prompt ${metadata.name}: ${error}`,
@@ -342,9 +698,16 @@ export class RegistryService {
         }
       }
     }
+
+    return Promise.resolve();
   }
 
-  private registerTools(server: McpServer) {
+  /** Synchronous by contract — see {@link registerResources}. */
+  private registerTools(
+    server: McpServer,
+    context: McpRegistrationContext | undefined,
+    pending: PendingCapabilityGate[],
+  ): Promise<void> {
     const toolMethods =
       this.discoveryService.getAllMethodsWithMetadata<ToolOptions>(MCP_TOOL);
 
@@ -357,13 +720,17 @@ export class RegistryService {
         this.wrappedHandler(instance, handler, args);
 
       try {
+        // The handle is bound so the toggle can disable it, then released with
+        // the loop iteration. Retaining handles is out of scope by design.
+        let handle: RegisteredTool;
+
         if (
           'paramsSchema' in metadata &&
           'annotations' in metadata &&
           'description' in metadata
         ) {
           // ToolWithParamsSchemaAndAnnotationsAndDescriptionOptions
-          server.tool(
+          handle = server.tool(
             metadata.name,
             metadata.description,
             metadata.paramsSchema,
@@ -372,7 +739,7 @@ export class RegistryService {
           );
         } else if ('paramsSchema' in metadata && 'annotations' in metadata) {
           // ToolWithParamsSchemaAndAnnotationsOptions
-          server.tool(
+          handle = server.tool(
             metadata.name,
             metadata.paramsSchema,
             metadata.annotations,
@@ -380,7 +747,7 @@ export class RegistryService {
           );
         } else if ('paramsSchema' in metadata && 'description' in metadata) {
           // ToolWithParamsSchemaAndDescriptionOptions
-          server.tool(
+          handle = server.tool(
             metadata.name,
             metadata.description,
             metadata.paramsSchema,
@@ -388,7 +755,7 @@ export class RegistryService {
           );
         } else if ('annotations' in metadata && 'description' in metadata) {
           // ToolWithAnnotationsAndDescriptionOptions
-          server.tool(
+          handle = server.tool(
             metadata.name,
             metadata.description,
             metadata.annotations,
@@ -396,17 +763,38 @@ export class RegistryService {
           );
         } else if ('paramsSchema' in metadata) {
           // ToolWithParamsSchemaOptions
-          server.tool(metadata.name, metadata.paramsSchema, wrappedHandler);
+          handle = server.tool(
+            metadata.name,
+            metadata.paramsSchema,
+            wrappedHandler,
+          );
         } else if ('annotations' in metadata) {
           // ToolWithAnnotationsOptions
-          server.tool(metadata.name, metadata.annotations, wrappedHandler);
+          handle = server.tool(
+            metadata.name,
+            metadata.annotations,
+            wrappedHandler,
+          );
         } else if ('description' in metadata) {
           // ToolWithDescriptionOptions
-          server.tool(metadata.name, metadata.description, wrappedHandler);
+          handle = server.tool(
+            metadata.name,
+            metadata.description,
+            wrappedHandler,
+          );
         } else {
           // ToolBaseOptions
-          server.tool(metadata.name, wrappedHandler);
+          handle = server.tool(metadata.name, wrappedHandler);
         }
+
+        this.applyCapabilityToggle(
+          metadata.enabled,
+          handle,
+          'Tool',
+          metadata.name,
+          'tools',
+          pending,
+        );
       } catch (error) {
         this.logger.error(
           `Error registering tool ${metadata.name}: ${error}`,
@@ -422,5 +810,7 @@ export class RegistryService {
         }
       }
     }
+
+    return Promise.resolve();
   }
 }

--- a/src/transports/sse/sse.service.spec.ts
+++ b/src/transports/sse/sse.service.spec.ts
@@ -18,6 +18,7 @@ describe('SseService', () => {
   let service: SseService;
   let sessionManager: SessionManager;
   let logger: McpLoggerService;
+  let registry: RegistryService;
 
   const createMockRequest = (
     overrides: Partial<Request> = {},
@@ -78,6 +79,7 @@ describe('SseService', () => {
     service = module.get<SseService>(SseService);
     sessionManager = module.get<SessionManager>(SessionManager);
     logger = module.get<McpLoggerService>(McpLoggerService);
+    registry = module.get<RegistryService>(RegistryService);
   });
 
   it('should be defined', () => {
@@ -248,11 +250,12 @@ describe('SseService', () => {
       };
       const createServerSpy = jest
         .spyOn(service as any, 'createServer')
-        .mockReturnValue(mockServer);
+        .mockResolvedValue(mockServer);
 
       await service.handleSse(req as Request, res as Response);
 
       expect(createServerSpy).toHaveBeenCalled();
+      expect(createServerSpy).toHaveBeenCalledWith(req);
       expect(mockServer.connect).toHaveBeenCalled();
 
       const sessions = Array.from(
@@ -283,7 +286,7 @@ describe('SseService', () => {
       const mockServer = {
         connect: jest.fn().mockResolvedValue(undefined),
       };
-      jest.spyOn(service as any, 'createServer').mockReturnValue(mockServer);
+      jest.spyOn(service as any, 'createServer').mockResolvedValue(mockServer);
 
       await service.handleSse(req as Request, res as unknown as Response);
 
@@ -299,6 +302,68 @@ describe('SseService', () => {
       closeHandler();
 
       expect(sessionManager.getSession(sessionId)).toBeUndefined();
+    });
+  });
+
+  describe('createServer', () => {
+    it('should build a registration context carrying request and authInfo', async () => {
+      const registerAllSpy = jest
+        .spyOn(registry, 'registerAll')
+        .mockResolvedValue(undefined);
+
+      const req = createMockRequest({
+        headers: { 'x-role': 'admin' },
+      }) as Request;
+      req.auth = { token: 'token', clientId: 'client', scopes: ['admin'] };
+
+      await service['createServer'](req);
+
+      expect(registerAllSpy).toHaveBeenCalledWith(expect.anything(), {
+        request: req,
+        authInfo: { token: 'token', clientId: 'client', scopes: ['admin'] },
+      });
+    });
+
+    it('should leave authInfo undefined when no auth middleware ran', async () => {
+      const registerAllSpy = jest
+        .spyOn(registry, 'registerAll')
+        .mockResolvedValue(undefined);
+
+      const req = createMockRequest() as Request;
+
+      await service['createServer'](req);
+
+      expect(registerAllSpy).toHaveBeenCalledWith(expect.anything(), {
+        request: req,
+        authInfo: undefined,
+      });
+    });
+
+    it('should not resolve until registration has completed', async () => {
+      // A missed `await` on registerAll inside createServer is only an eslint
+      // warning, so nothing but this catches it: the server would be connected
+      // to its transport with gates still in flight — fail-open under load.
+      let registrationDone = false;
+      let release!: () => void;
+      const registration = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+
+      jest.spyOn(registry, 'registerAll').mockImplementation(() =>
+        registration.then(() => {
+          registrationDone = true;
+        }),
+      );
+
+      const req = createMockRequest() as Request;
+      const pending = service['createServer'](req);
+
+      expect(registrationDone).toBe(false);
+
+      release();
+      await pending;
+
+      expect(registrationDone).toBe(true);
     });
   });
 

--- a/src/transports/sse/sse.service.ts
+++ b/src/transports/sse/sse.service.ts
@@ -102,9 +102,22 @@ export class SseService implements OnModuleInit {
     }
   }
 
-  private createServer(): McpServer {
+  /**
+   * Builds the `McpServer` for one client connection.
+   *
+   * The request is threaded into registration so `enabled` gates can be
+   * evaluated against this connection's context. `sessionId` is deliberately
+   * not part of that context: it exists here but not under streamable HTTP.
+   *
+   * Awaits registration: the returned server's capability set is final, so the
+   * caller may connect it to its transport immediately.
+   */
+  private async createServer(req: Request): Promise<McpServer> {
     const server = new McpServer(this.options.serverInfo, this.options.options);
-    this.registry.registerAll(server);
+    await this.registry.registerAll(server, {
+      request: req,
+      authInfo: req.auth,
+    });
     return server;
   }
 
@@ -157,7 +170,7 @@ export class SseService implements OnModuleInit {
     });
 
     try {
-      const server = this.createServer();
+      const server = await this.createServer(req);
       await server.connect(transport);
     } catch (error) {
       this.logger.error('Failed to create or connect server', error, 'SSE');

--- a/src/transports/streamable/streamable.service.spec.ts
+++ b/src/transports/streamable/streamable.service.spec.ts
@@ -18,6 +18,7 @@ describe('StreamableService', () => {
   let service: StreamableService;
   let sessionManager: SessionManager;
   let logger: McpLoggerService;
+  let registry: RegistryService;
 
   const createMockRequest = (
     overrides: Partial<Request> = {},
@@ -78,6 +79,7 @@ describe('StreamableService', () => {
     service = module.get<StreamableService>(StreamableService);
     sessionManager = module.get<SessionManager>(SessionManager);
     logger = module.get<McpLoggerService>(McpLoggerService);
+    registry = module.get<RegistryService>(RegistryService);
   });
 
   it('should be defined', () => {
@@ -151,7 +153,7 @@ describe('StreamableService', () => {
       };
       const createServerSpy = jest
         .spyOn(service as any, 'createServer')
-        .mockReturnValue(mockServer);
+        .mockResolvedValue(mockServer);
 
       const req = createMockRequest({
         headers: {},
@@ -173,7 +175,71 @@ describe('StreamableService', () => {
       ).rejects.toThrow();
 
       expect(createServerSpy).toHaveBeenCalled();
+      expect(createServerSpy).toHaveBeenCalledWith(req);
       expect(res.status).not.toHaveBeenCalledWith(400);
+    });
+  });
+
+  describe('createServer', () => {
+    it('should build a registration context carrying request and authInfo', async () => {
+      const registerAllSpy = jest
+        .spyOn(registry, 'registerAll')
+        .mockResolvedValue(undefined);
+
+      const req = createMockRequest({
+        headers: { 'x-role': 'admin' },
+      }) as Request;
+      req.auth = { token: 'token', clientId: 'client', scopes: ['admin'] };
+
+      await service['createServer'](req);
+
+      expect(registerAllSpy).toHaveBeenCalledWith(expect.anything(), {
+        request: req,
+        authInfo: { token: 'token', clientId: 'client', scopes: ['admin'] },
+      });
+    });
+
+    it('should leave authInfo undefined when no auth middleware ran', async () => {
+      const registerAllSpy = jest
+        .spyOn(registry, 'registerAll')
+        .mockResolvedValue(undefined);
+
+      const req = createMockRequest() as Request;
+
+      await service['createServer'](req);
+
+      expect(registerAllSpy).toHaveBeenCalledWith(expect.anything(), {
+        request: req,
+        authInfo: undefined,
+      });
+    });
+
+    it('should not resolve until registration has completed', async () => {
+      // Streamable is the sharper column: createServer runs before
+      // transport.handleRequest answers `initialize`, so an un-awaited
+      // registration would advertise capabilities whose gates are still
+      // in flight.
+      let registrationDone = false;
+      let release!: () => void;
+      const registration = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+
+      jest.spyOn(registry, 'registerAll').mockImplementation(() =>
+        registration.then(() => {
+          registrationDone = true;
+        }),
+      );
+
+      const req = createMockRequest() as Request;
+      const pending = service['createServer'](req);
+
+      expect(registrationDone).toBe(false);
+
+      release();
+      await pending;
+
+      expect(registrationDone).toBe(true);
     });
   });
 

--- a/src/transports/streamable/streamable.service.ts
+++ b/src/transports/streamable/streamable.service.ts
@@ -106,9 +106,24 @@ export class StreamableService implements OnModuleInit {
     }
   }
 
-  private createServer(): McpServer {
+  /**
+   * Builds the `McpServer` for one client connection.
+   *
+   * The request is threaded into registration so `enabled` gates can be
+   * evaluated against this connection's context. `sessionId` is deliberately
+   * not part of that context: the transport only assigns it while handling
+   * the `initialize` POST, which happens after this method returns.
+   *
+   * Awaits registration, which runs before `transport.handleRequest` answers
+   * the client's `initialize` — every gate settles before the client is told
+   * what this server offers. Keep gates cheap: they are on the connect path.
+   */
+  private async createServer(req: Request): Promise<McpServer> {
     const server = new McpServer(this.options.serverInfo, this.options.options);
-    this.registry.registerAll(server);
+    await this.registry.registerAll(server, {
+      request: req,
+      authInfo: req.auth,
+    });
     return server;
   }
 
@@ -199,7 +214,7 @@ export class StreamableService implements OnModuleInit {
       };
 
       try {
-        const server = this.createServer();
+        const server = await this.createServer(req);
         await server.connect(transport);
       } catch (error) {
         this.logger.error(

--- a/test/dynamic-capabilities.e2e-spec.ts
+++ b/test/dynamic-capabilities.e2e-spec.ts
@@ -1,0 +1,307 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import {
+  CallToolResult,
+  ErrorCode,
+  TextContent,
+} from '@modelcontextprotocol/sdk/types';
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Server } from 'http';
+import { AddressInfo } from 'net';
+
+import { AppModule } from '../examples/dynamic/app.module';
+
+/**
+ * The gate design on the wire, over both transports.
+ *
+ * The capability set is decided once per connection by classes resolved from
+ * the Nest container and awaited, so every case here opens its own connection:
+ * that is the unit of behaviour under test. Connections are always closed in a
+ * `finally` — a leaked SSE stream keeps reconnecting and hangs `app.close()`.
+ */
+
+/** The header `examples/dynamic`'s `AdminGate` keys on. */
+const ADMIN_HEADERS: Record<string, string> = { 'x-role': 'admin' };
+
+interface Connection {
+  client: Client;
+  close: () => Promise<void>;
+  /** Every notification method received on this connection, in order. */
+  notifications: string[];
+}
+
+type Connect = (headers?: Record<string, string>) => Promise<Connection>;
+
+describe('Dynamic capabilities (e2e)', () => {
+  let app: INestApplication;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.listen(0);
+
+    const server = app.getHttpServer() as Server;
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://localhost:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const newClient = (): { client: Client; notifications: string[] } => {
+    const client = new Client({ name: 'dynamic-client', version: '1.0.0' });
+    const notifications: string[] = [];
+
+    // Set before connect: a frame emitted during the handshake still lands here.
+    client.fallbackNotificationHandler = (notification) => {
+      notifications.push(notification.method);
+      return Promise.resolve();
+    };
+
+    return { client, notifications };
+  };
+
+  const connectStreamable: Connect = async (headers) => {
+    const { client, notifications } = newClient();
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`${baseUrl}/mcp`),
+      headers ? { requestInit: { headers } } : undefined,
+    );
+
+    await client.connect(transport);
+
+    return { client, notifications, close: () => transport.close() };
+  };
+
+  const connectSse: Connect = async (headers) => {
+    const { client, notifications } = newClient();
+    // `requestInit.headers` is merged into the initial `GET /sse` too
+    // (SDK `sse.js` `_commonHeaders`), which is the request registration sees.
+    const transport = new SSEClientTransport(
+      new URL(`${baseUrl}/sse`),
+      headers ? { requestInit: { headers } } : undefined,
+    );
+
+    await client.connect(transport);
+
+    return { client, notifications, close: () => transport.close() };
+  };
+
+  const toolNames = async (connection: Connection): Promise<string[]> => {
+    const { tools } = await connection.client.listTools();
+    return tools.map((tool) => tool.name);
+  };
+
+  const transports = [
+    { label: 'Streamable HTTP', connect: connectStreamable },
+    { label: 'SSE', connect: connectSse },
+  ];
+
+  describe.each(transports)('$label', ({ connect }) => {
+    it('omits a statically disabled tool from tools/list', async () => {
+      const connection = await connect();
+
+      try {
+        const names = await toolNames(connection);
+
+        expect(names).toContain('public_tool');
+        expect(names).not.toContain('always_off_tool');
+      } finally {
+        await connection.close();
+      }
+    });
+
+    it('omits a tool whose DI-resolved async gate answered false and lists it when the request satisfies the gate', async () => {
+      const anonymous = await connect();
+      const admin = await connect(ADMIN_HEADERS);
+
+      try {
+        // `AdminGate` reaches `PermissionsService` through the container and
+        // answers on a later tick. A pending promise is truthy, so an
+        // implementation that skipped the await would list this for everyone.
+        expect(await toolNames(anonymous)).not.toContain('admin_only_tool');
+        expect(await toolNames(admin)).toContain('admin_only_tool');
+      } finally {
+        await anonymous.close();
+        await admin.close();
+      }
+    });
+
+    it('applies a gate to prompts and resources as well as tools', async () => {
+      const anonymous = await connect();
+      const admin = await connect(ADMIN_HEADERS);
+
+      try {
+        const promptsFor = async (connection: Connection) =>
+          (await connection.client.listPrompts()).prompts.map((p) => p.name);
+        const resourcesFor = async (connection: Connection) =>
+          (await connection.client.listResources()).resources.map(
+            (r) => r.name,
+          );
+
+        expect(await promptsFor(anonymous)).not.toContain('admin_only_prompt');
+        expect(await promptsFor(admin)).toContain('admin_only_prompt');
+
+        expect(await resourcesFor(anonymous)).not.toContain(
+          'admin_only_resource',
+        );
+        expect(await resourcesFor(admin)).toContain('admin_only_resource');
+      } finally {
+        await anonymous.close();
+        await admin.close();
+      }
+    });
+
+    it('lists a tool whose slow gate answered true, without dropping the fast ones', async () => {
+      const connection = await connect();
+
+      try {
+        const names = await toolNames(connection);
+
+        // `BetaGate` takes ~100ms and settles in the same wave as the others.
+        expect(names).toContain('beta_tool');
+        expect(names).toContain('public_tool');
+      } finally {
+        await connection.close();
+      }
+    });
+
+    it('fails closed for a gate that throws synchronously, without dropping its siblings', async () => {
+      const connection = await connect();
+
+      try {
+        const names = await toolNames(connection);
+
+        expect(names).not.toContain('throwing_gate_tool');
+        expect(names).toContain('public_tool');
+      } finally {
+        await connection.close();
+      }
+    });
+
+    it('fails closed for a gate whose promise rejects', async () => {
+      const connection = await connect();
+
+      try {
+        const names = await toolNames(connection);
+
+        // Distinct from the synchronous throw above: a try/catch around the
+        // call instead of around the await catches that one and misses this.
+        expect(names).not.toContain('rejecting_gate_tool');
+        expect(names).toContain('public_tool');
+      } finally {
+        await connection.close();
+      }
+    });
+
+    it('fails closed for a gate class the container cannot resolve', async () => {
+      const connection = await connect();
+
+      try {
+        const names = await toolNames(connection);
+
+        // It must not be silently built with `new`: such a gate has undefined
+        // dependencies and could answer something accidentally truthy.
+        expect(names).not.toContain('unresolvable_gate_tool');
+        expect(names).toContain('public_tool');
+      } finally {
+        await connection.close();
+      }
+    });
+
+    it('answers a call to a disabled tool with "disabled", not "not found"', async () => {
+      const connection = await connect();
+
+      try {
+        const result = (await connection.client.callTool({
+          name: 'always_off_tool',
+          arguments: {},
+        })) as CallToolResult;
+
+        // The whole reason the SPEC chose register-then-disable over
+        // skip-registration: the client is told the tool exists but is off.
+        //
+        // Shape note, verified against the pinned SDK 1.30.0: the disabled
+        // check throws `McpError(InvalidParams, 'Tool <name> disabled')` at
+        // `mcp.js:106-107`, but the surrounding handler catches it and returns
+        // it as a tool-error result (`mcp.js:135-141`, `createToolError`)
+        // rather than a JSON-RPC error. The distinguishing text is what
+        // matters and it is intact.
+        expect(result.isError).toBe(true);
+
+        const text = (result.content[0] as TextContent).text;
+        expect(text).toContain('Tool always_off_tool disabled');
+        expect(text).toContain(String(ErrorCode.InvalidParams));
+        expect(text).not.toContain('not found');
+      } finally {
+        await connection.close();
+      }
+    });
+
+    it('omits disabled prompts and resources from their lists', async () => {
+      const connection = await connect();
+
+      try {
+        const { prompts } = await connection.client.listPrompts();
+        const { resources } = await connection.client.listResources();
+
+        const promptNames = prompts.map((prompt) => prompt.name);
+        expect(promptNames).toContain('public_prompt');
+        expect(promptNames).not.toContain('always_off_prompt');
+
+        const resourceNames = resources.map((resource) => resource.name);
+        expect(resourceNames).toContain('public_resource');
+        expect(resourceNames).not.toContain('always_off_resource');
+      } finally {
+        await connection.close();
+      }
+    });
+
+    it('emits no list_changed notification during connect', async () => {
+      const connection = await connect(ADMIN_HEADERS);
+
+      try {
+        // Registration — and therefore every disable() — happens before
+        // server.connect(transport), where the SDK gates dispatch on
+        // isConnected(). Any frame here means the library dispatched on its own.
+        await connection.client.listTools();
+        await new Promise((resolve) => setTimeout(resolve, 500));
+
+        expect(
+          connection.notifications.filter((method) =>
+            method.includes('list_changed'),
+          ),
+        ).toEqual([]);
+      } finally {
+        await connection.close();
+      }
+    });
+
+    it('gives two concurrent connections with different request context different capability sets', async () => {
+      const anonymous = await connect();
+      const admin = await connect(ADMIN_HEADERS);
+
+      try {
+        const anonymousNames = await toolNames(anonymous);
+        const adminNames = await toolNames(admin);
+
+        expect(anonymousNames).not.toContain('admin_only_tool');
+        expect(adminNames).toContain('admin_only_tool');
+
+        // Neither connection's set moved because the other one exists.
+        expect(await toolNames(anonymous)).toEqual(anonymousNames);
+        expect(await toolNames(admin)).toEqual(adminNames);
+      } finally {
+        await anonymous.close();
+        await admin.close();
+      }
+    });
+  });
+});


### PR DESCRIPTION
Availability is decided once per connection by a gate class the Nest container resolves, so it can inject services and answer asynchronously.

- docs: document the toggle, the five fail-closed cases and the guard boundary
- interfaces: add McpCapabilityGate and McpCapabilityToggle
- decorators: optional `enabled` on the Tool, Prompt and Resource base options
- registry: resolve each gate through the container, mirroring resolveGuard
- registry: settle every gate in one Promise.all wave
- registry: fail closed on throw, rejection, unresolvable gate or missing context
- registry: register then disable, so the SDK answers "disabled" not "not found"
- transports: await registration before serving, on SSE and streamable HTTP
- examples: dynamic example gating on an injected PermissionsService
- test: e2e over both transports for list absence and the disabled answer

BREAKING CHANGE: RegistryService.registerAll now returns Promise<void> and must be awaited. Callers that ignore it continue while registration is still in flight.

Closes #30