### PR TITLE
ci(release): consolidate pre-releases onto a single next channel

### DIFF
--- a/.claude/skills/github-issues/SKILL.md
+++ b/.claude/skills/github-issues/SKILL.md
@@ -118,7 +118,7 @@ propose creating it to the user and wait, or leave it off.
 | `priority: high` | See Priority | manually |
 | `priority: medium` | See Priority | manually |
 | `priority: low` | See Priority | manually |
-| `released on @rc` | Shipped in a pre-release | semantic-release automation — **never set by hand** |
+| `released on @next` | Shipped in a pre-release | semantic-release automation — **never set by hand** |
 | `high-priority` | **Legacy.** Superseded by `priority: high`. | — do not apply to new issues |
 
 **Rules:**
@@ -127,7 +127,9 @@ propose creating it to the user and wait, or leave it off.
 - `triage` means "a maintainer has not assessed this yet". When *you* author the issue after a
   diagnosis or a specification, it is already assessed — **omit `triage`** and state why in the
   proposal. When you file an inbound report on someone's behalf, keep it.
-- Never set `released on @rc`. It belongs to the release automation (`.releaserc.js`).
+- Never set `released on @next`. It belongs to the release automation (`.releaserc.js`), which
+  derives the label name from the pre-release channel. A legacy `released on @rc` label still
+  exists from the retired three-channel model; do not apply it either.
 - **This table is not exhaustive** — it lists what has been observed, and the repository has more
   labels than any single query returns. Before applying a label that is not here, confirm it with
   `get_label`; before concluding a label does *not* exist, confirm that too. `priority: low` was
@@ -584,7 +586,7 @@ is:open label:triage
 - [ ] Body follows the mode's template, with the form's section headers, in the form's order.
 - [ ] Reporter-only fields dropped, not answered with invented values (ReporterOnlyFields).
 - [ ] Every `file:line` came from a `codegraph_*` or `Read` call run **this session**.
-- [ ] Labels: exactly one type label; every label confirmed to exist; no `released on @rc`; no invented `debt`/`priority: low`.
+- [ ] Labels: exactly one type label; every label confirmed to exist; no `released on @next`; no invented `debt`/`priority: low`.
 - [ ] Duplicate check ran, open **and** closed, with no unaddressed match.
 - [ ] The full title + body + label list was shown to the user and they authorized **this** batch.
 </PreCreateChecklist>
@@ -680,7 +682,7 @@ forever. A debt item without a checkable condition is the status quo.
   <Pitfall>Updating an issue body at all. Nothing in this pipeline does; if you are reaching for it, re-read what stage you are in.</Pitfall>
   <Pitfall>Running `/security-review` from `/specification`. There is no diff yet; it reviews unrelated uncommitted work and reports irrelevant findings (ConsultAxes → SecurityAxisByStage).</Pitfall>
   <Pitfall>Inventing a label. `debt`, `priority: low`, `wontfix`, `good first issue` — confirm with `get_label` or leave it off; creating one is a repository mutation.</Pitfall>
-  <Pitfall>Setting `released on @rc` by hand — it belongs to semantic-release.</Pitfall>
+  <Pitfall>Setting `released on @next` by hand — it belongs to semantic-release.</Pitfall>
   <Pitfall>Answering reporter-only form fields (Prerequisites, Code of Conduct, Package Version) with invented values on a maintainer-authored issue.</Pitfall>
   <Pitfall>Putting a time estimate in `Estimated Effort` — `CLAUDE.md` prohibits estimates outright. State scope.</Pitfall>
   <Pitfall>Creating an issue without diagnosis ("investigate X" / "TBD"). Diagnose first.</Pitfall>

--- a/.github/workflows/pr-branch-validation.yml
+++ b/.github/workflows/pr-branch-validation.yml
@@ -22,7 +22,8 @@ jobs:
 
           # Validate branch relationships based on workflow rules
           # Allowed: feature/*, bugfix/* → main
-          # Pre-release branches (alpha, beta, rc) are handled by semantic-release
+          # The `next` pre-release branch is published by semantic-release on every push,
+          # and is promoted to main through a pull request like any other branch.
           if [[ "$SOURCE_TYPE" == "feature" ]] || [[ "$SOURCE_TYPE" == "bugfix" ]]; then
             if [[ "$TARGET_BRANCH" != "main" ]]; then
               echo "ERROR: feature and bugfix branches must target the main branch."
@@ -30,10 +31,10 @@ jobs:
             fi
             echo "PR branch validation passed"
 
-          elif [[ "$SOURCE_BRANCH" == "alpha" ]] || [[ "$SOURCE_BRANCH" == "beta" ]] || [[ "$SOURCE_BRANCH" == "rc" ]]; then
-            # Pre-release branches can be merged to main
+          elif [[ "$SOURCE_BRANCH" == "next" ]]; then
+            # The pre-release branch can be promoted to main
             if [[ "$TARGET_BRANCH" != "main" ]]; then
-              echo "ERROR: pre-release branches (alpha, beta, rc) must target the main branch."
+              echo "ERROR: the next branch must target the main branch."
               exit 1
             fi
             echo "PR branch validation passed"
@@ -41,6 +42,6 @@ jobs:
           else
             echo "ERROR: Unknown branch type: $SOURCE_TYPE"
             echo "Allowed branch prefixes: feature/, bugfix/"
-            echo "Allowed pre-release branches: alpha, beta, rc"
+            echo "Allowed pre-release branch: next"
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,12 +9,10 @@ on:
         type: boolean
         default: false
 
-  # Automatic trigger for pre-releases
+  # Automatic trigger for pre-releases: every push to `next` publishes X.Y.Z-next.N
   push:
     branches:
-      - alpha
-      - beta
-      - rc
+      - next
 
 concurrency:
   group: release-${{ github.ref }}

--- a/.handbook/GIT_GUIDELINES.md
+++ b/.handbook/GIT_GUIDELINES.md
@@ -29,14 +29,12 @@ This document outlines our Git workflow, branch naming conventions, and commit m
 
 We follow a trunk-based development workflow with the following branches:
 
-| Branch Type   | Created From | PR Target | Purpose                              |
-| ------------- | ------------ | --------- | ------------------------------------ |
-| `main`        | -            | -         | Stable production code               |
-| `feature/*`   | `main`       | `main`    | New features and enhancements        |
-| `bugfix/*`    | `main`       | `main`    | Bug fixes                            |
-| `alpha`       | `main`       | `main`    | Early preview pre-releases (optional)|
-| `beta`        | `main`       | `main`    | Feature-complete pre-releases (optional)|
-| `rc`          | `main`       | `main`    | Release candidates (optional)        |
+| Branch Type   | Created From | PR Target | Purpose                                        |
+| ------------- | ------------ | --------- | ---------------------------------------------- |
+| `main`        | -            | -         | Stable production code, published to `@latest` |
+| `feature/*`   | `main`       | `main`    | New features and enhancements                  |
+| `bugfix/*`    | `main`       | `main`    | Bug fixes                                      |
+| `next`        | `main`       | `main`    | Pre-releases, published to `@next` (optional)  |
 
 ## Workflow Diagram
 
@@ -52,26 +50,24 @@ gitGraph
    checkout main
    merge bugfix/issue-2
    commit id: "Release v1.0.0" tag: "v1.0.0"
-   branch beta
+   branch next
    commit id: "feat: new feature"
-   commit id: "v1.1.0-beta.1" tag: "v1.1.0-beta.1"
+   commit id: "v1.1.0-next.1" tag: "v1.1.0-next.1"
    checkout main
-   merge beta tag: "v1.1.0"
+   merge next tag: "v1.1.0"
 ```
 
 **Key points:**
 - All development branches are created from `main`
 - All branches create PRs to `main`
-- Releases are triggered manually via GitHub Actions workflow dispatch
-- Pre-release branches (`alpha`, `beta`, `rc`) are optional and temporary
+- Stable releases are triggered manually via GitHub Actions workflow dispatch
+- The `next` branch is optional; it exists only when a pre-release is in flight
 
 ## Branch Naming Conventions
 
 - `feature/issue-{id}-{short-description}`: For new features
 - `bugfix/issue-{id}-{short-description}`: For bug fixes
-- `alpha`: For early preview pre-releases
-- `beta`: For feature-complete pre-releases
-- `rc`: For release candidates
+- `next`: The pre-release branch (exact name — it is declared in `.releaserc.js`)
 
 Examples:
 
@@ -160,7 +156,7 @@ If conflicts arise when merging:
 
 - Only `main` branch accepts pull requests
 - The `main` branch **must be protected** against direct push and force push. Only merges via pull request are allowed.
-- All other branches (e.g., `feature/*`, `bugfix/*`, `alpha`, `beta`, `rc`) can receive updates via direct push.
+- All other branches (e.g., `feature/*`, `bugfix/*`, `next`) can receive updates via direct push.
 - The `github-actions[bot]` must be allowed to push to `main` for semantic-release to update package.json and CHANGELOG.
 
 ## Revert and Rebase Policy
@@ -177,7 +173,16 @@ All releases are automated via **semantic-release**:
 - npm publishing is handled automatically
 - GitHub Releases are created automatically
 
-To trigger a release, go to **GitHub Actions → Release → Run workflow**.
+There are exactly two ways a release runs:
+
+| Trigger | Branch | Result |
+| ------- | ------ | ------ |
+| **GitHub Actions → Release → Run workflow** (manual) | `main` | Stable version on `@latest` |
+| Any push (automatic) | `next` | Pre-release on `@next` |
+
+Stable releases are deliberately manual so that several merged PRs can be batched into one
+version. The manual run accepts a `dry_run` input that reports the version it *would* publish
+without publishing anything — use it before any major.
 
 ## Release Process
 
@@ -196,44 +201,69 @@ To trigger a release, go to **GitHub Actions → Release → Run workflow**.
 
 ### Pre-releases
 
-For early testing before a stable release:
+Use a pre-release when consumers should be able to install and test a change — typically a
+breaking major — before it reaches `@latest`.
 
-1. Create a pre-release branch from `main`:
+> **The pre-release channel is a branch, not a tag.** `next` is a **branch name**, declared
+> under `branches` in `.releaserc.js`. The git tag (`v2.0.0-next.1`) and the npm dist-tag
+> (`@next`) are **outputs** semantic-release creates when it runs on that branch. You never
+> create them by hand: pushing a tag yourself publishes nothing, because the Release workflow
+> triggers on branches, not tags. One branch maps to exactly one dist-tag — that binding is
+> why the channel is expressed as a branch in the first place.
+
+1. Create the pre-release branch from `main`:
+
    ```bash
-   git checkout main
-   git checkout -b beta  # or alpha, or rc
-   git push origin beta
+   git checkout main && git pull
+   git checkout -b next
+   git push origin next
    ```
 
-2. Push commits to the pre-release branch:
-   - Each push automatically publishes a pre-release
-   - Example: `0.5.0-beta.1`, `0.5.0-beta.2`, etc.
+   From this moment `main` is frozen — see [Version Freeze](#version-freeze). Anything merged to
+   `main` before step 4 ends up in the stable release without ever having been previewed.
 
-3. Typical progression:
-   ```
-   main → alpha (0.5.0-alpha.1) → beta (0.5.0-beta.1) → rc (0.5.0-rc.1) → main (0.5.0)
-   ```
+2. Push commits to `next`. Every push triggers the Release workflow automatically
+   (`on.push.branches` in `.github/workflows/release.yml`), and semantic-release then:
+   - tags the commit `v2.0.0-next.1`
+   - publishes it to npm under the `@next` dist-tag, installable with
+     `npm install @nestjs-mcp/server@next`
+   - produces `v2.0.0-next.2` on the next push, and so on
 
-4. When ready, merge the pre-release branch to `main` and trigger a release:
-   ```bash
-   git checkout main
-   git merge beta
-   git push origin main
-   # Go to GitHub Actions → Release → Run workflow
-   ```
+3. Promote to stable by opening a **pull request from `next` to `main`**. `main` is protected,
+   so a direct push is rejected — see
+   [Branch Protection and Pull Request Rules](#branch-protection-and-pull-request-rules).
+   Merge it with a **merge commit, not a squash**, so the original `feat:` / `fix:` subjects
+   reach `main` intact; a squash collapses them into one subject that must then carry the
+   version-bump marker itself.
 
-5. Delete the pre-release branch after the stable release.
+4. Cut the stable version: **GitHub Actions → Release → Run workflow** on `main`.
+
+5. Delete `next`. It is recreated from `main` the next time a pre-release is needed. Leaving it
+   configured in `.releaserc.js` while the branch does not exist is harmless — semantic-release
+   only requires that the branch it is *currently running on* be configured.
 
 ### Version Freeze
 
-When you need to isolate a release while development continues:
+**While a pre-release is in flight, `main` is frozen.** The stable release is computed from
+everything on `main`, so anything merged during the cycle ships in that release whether or not it
+was ever previewed. Freezing is what makes the preview representative of what gets published.
 
-1. Create an `rc` branch from `main`
-2. Continue development on `main` for the next version
-3. Only merge stabilization fixes to `rc`
-4. Each push to `rc` publishes a release candidate
-5. When stable, merge `rc` to `main` and trigger final release
-6. Delete the `rc` branch
+1. Cut `next` from `main`. Whatever is on `main` at that moment is what the release will contain.
+2. **Stop merging to `main`.** Pull requests can still be opened, reviewed and approved — they
+   simply wait. This is the entire mechanism; no CI check enforces it.
+3. Send stabilization fixes to `next`, never to `main`. Each push publishes a new `@next`
+   pre-release, so the fixes get previewed too.
+4. Promote: PR from `next` to `main`, merged with a merge commit. This is what brings the fixes
+   back to `main`.
+5. Cut the stable version: **GitHub Actions → Release → Run workflow** on `main`.
+6. Delete `next`. The freeze is over — merge whatever was waiting.
+
+The window runs from step 1 to step 5; keeping it short is what makes the freeze cheap.
+
+If the freeze is broken, the release silently includes unpreviewed code. `dry_run` will not catch
+it — it reports the version that would be published, not where each commit came from. Should
+freezing ever become too costly, the alternative is a dedicated release branch so that `main` can
+keep moving; that is a larger restructuring than this document describes.
 
 ## SemVer Versioning
 
@@ -246,9 +276,8 @@ We follow Semantic Versioning (SemVer) for our releases:
 
 Pre-release versions:
 
-- `-alpha.N`: Early preview, unstable
-- `-beta.N`: Feature-complete, may have bugs
-- `-rc.N`: Release candidate, stable unless critical bugs found
+- `-next.N`: Preview of the upcoming version, published from the `next` branch to the `@next`
+  npm dist-tag. `N` increments on every push to that branch.
 
 Examples:
 
@@ -256,4 +285,4 @@ Examples:
 - `1.1.0`: New feature added
 - `1.1.1`: Bug fix
 - `2.0.0`: Breaking changes
-- `2.0.0-beta.1`: Beta pre-release for 2.0.0
+- `2.0.0-next.1`: Pre-release preview of 2.0.0

--- a/.handbook/PACKAGE_VERSIONING.md
+++ b/.handbook/PACKAGE_VERSIONING.md
@@ -32,7 +32,7 @@ MAJOR.MINOR.PATCH[-PRERELEASE]
 - **MAJOR**: Incompatible API changes
 - **MINOR**: Backwards-compatible functionality
 - **PATCH**: Backwards-compatible bug fixes
-- **PRERELEASE**: Optional, for alpha/beta/rc versions
+- **PRERELEASE**: Optional, for pre-release versions (`-next.N`)
 
 ## Version Bump Rules
 
@@ -60,18 +60,20 @@ Result: 0.4.0 → 0.5.0 (MINOR wins)
 
 ## Pre-release Identifiers
 
-Pre-release versions are denoted by a hyphen and a label after the patch number:
+Pre-release versions are denoted by a hyphen and a label after the patch number. This project
+uses a single pre-release identifier, `next`:
 
-- `-alpha.N`: Early preview, unstable, not feature-complete
-- `-beta.N`: Feature-complete, but may contain known issues
-- `-rc.N`: Release candidate, stable unless critical bugs are found
+- `-next.N`: Preview of the upcoming version. `N` increments on every push to the `next` branch.
 
 **Examples:**
 
-- `1.2.0-alpha.1`
-- `1.2.0-beta.2`
-- `1.2.0-rc.1`
+- `1.2.0-next.1`
+- `1.2.0-next.2`
 - `1.2.0` (final release)
+
+> The identifier is derived from the **branch name**, not chosen per release. `next` is a branch
+> declared in `.releaserc.js`; the version suffix and the npm dist-tag are both generated from it.
+> Adding a second identifier would mean adding a second branch.
 
 ## Release Flow
 
@@ -93,17 +95,20 @@ Pre-release versions are denoted by a hyphen and a label after the patch number:
 
 For early testing before a stable release:
 
-1. **Create branch**: `git checkout -b beta` (or `alpha`, `rc`)
-2. **Push**: `git push origin beta`
+1. **Create branch**: `git checkout -b next` from an up-to-date `main`
+2. **Push**: `git push origin next`
 3. **Automatic publish**: Each push triggers a pre-release
-   - First push: `0.5.0-beta.1`
-   - Second push: `0.5.0-beta.2`
+   - First push: `0.5.0-next.1`
+   - Second push: `0.5.0-next.2`
    - etc.
-4. **Promote to stable**: Merge to `main` and trigger release workflow
+4. **Promote to stable**: open a PR from `next` to `main`, merge it with a merge commit (not a
+   squash), then trigger the Release workflow
+5. **Clean up**: delete `next`; recreate it from `main` when the next pre-release is needed
 
-**Typical progression:**
+**Typical progression** — `next` and `main` below are *branches*; the versions in parentheses are
+what each publishes:
 ```
-main → alpha (0.5.0-alpha.1, alpha.2) → beta (0.5.0-beta.1) → rc (0.5.0-rc.1) → main (0.5.0)
+main (0.4.0) → next branch (0.5.0-next.1, 0.5.0-next.2, …) → main (0.5.0)
 ```
 
 ## Automation with semantic-release
@@ -129,16 +134,19 @@ npm tags are assigned automatically based on the release type:
 | Branch | npm Tag | Example Installation |
 |--------|---------|---------------------|
 | `main` | `latest` | `npm install @nestjs-mcp/server` |
-| `alpha` | `alpha` | `npm install @nestjs-mcp/server@alpha` |
-| `beta` | `beta` | `npm install @nestjs-mcp/server@beta` |
-| `rc` | `rc` | `npm install @nestjs-mcp/server@rc` |
+| `next` | `next` | `npm install @nestjs-mcp/server@next` |
+
+The npm tag always matches the branch name — `@semantic-release/npm` derives it from the branch's
+channel, so there is no way to publish a given branch under a different tag without renaming the
+branch in `.releaserc.js`.
 
 ## Best Practices
 
 1. **Use conventional commits**: Version bumps depend on commit message format
 2. **Breaking changes**: Always use `feat!:` or include `BREAKING CHANGE:` in footer
 3. **Test before release**: Run `--dry-run` option in the release workflow to preview
-4. **Pre-release for risky changes**: Use alpha/beta branches for significant changes
+4. **Pre-release for risky changes**: Ship significant or breaking changes through the `next`
+   branch first, so consumers can install them from `@next` before they reach `@latest`
 5. **Document breaking changes**: The CHANGELOG will include them automatically
 
 ---

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -4,10 +4,11 @@
  */
 module.exports = {
   branches: [
+    // Stable channel: released manually via the Release workflow -> npm `latest`.
     'main',
-    { name: 'alpha', prerelease: true },
-    { name: 'beta', prerelease: true },
-    { name: 'rc', prerelease: true },
+    // Pre-release channel: every push publishes X.Y.Z-next.N -> npm `next`.
+    // The channel name is derived from the branch name, so one branch == one dist-tag.
+    { name: 'next', prerelease: true },
   ],
   plugins: [
     [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,9 +85,9 @@ Typecheck verifies code correctness, not feature correctness. If the public API 
 
 Read `.handbook/GIT_GUIDELINES.md` before pushing.
 
-- Branches: `feature/issue-{id}-{desc}`, `bugfix/issue-{id}-{desc}`, plus `alpha`, `beta`, `rc` for pre-releases.
+- Branches: `feature/issue-{id}-{desc}`, `bugfix/issue-{id}-{desc}`, plus `next` for pre-releases.
 - Commits: Conventional (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`). Version bumps are automatic via semantic-release.
-- PRs target `main`. Releases run via GitHub Actions workflow_dispatch.
+- PRs target `main`. Stable releases run via GitHub Actions workflow_dispatch on `main` (npm `@latest`); every push to `next` auto-publishes a pre-release (npm `@next`).
 
 ## When updating package version policy
 


### PR DESCRIPTION
Replace the alpha/beta/rc pre-release branches with a single `next` channel in .releaserc.js, and align the release and PR-validation workflows with it.

The three-channel model was never practised: `beta` produced no tags at all, `alpha` none since v0.2.0, and the one `rc` branch was abandoned without being merged. The handbook compounded this by presenting the channels as version tags and instructing a direct push to `main`, which branch protection rejects and which pr-branch-validation.yml already contradicted.

Rewrite both handbook documents to state that the channel is a branch and that git tags and npm dist-tags are outputs semantic-release derives from it, and to promote through a pull request merged with a merge commit.

Rename the `released on @rc` label reference to `released on @next` in the github-issues skill, since @semantic-release/github derives the label name from the channel.